### PR TITLE
feat: handle partial factors for materials

### DIFF
--- a/structuralcodes/codes/ec2_2004/_reinforcement_material_properties.py
+++ b/structuralcodes/codes/ec2_2004/_reinforcement_material_properties.py
@@ -18,7 +18,7 @@ DUCTILITY_CLASSES = {
 }
 
 
-def fyd(fyk: float, gamma_s: float = 1.15) -> float:
+def fyd(fyk: float, gamma_s: float) -> float:
     """Calculate the design value of the reinforcement yield strength.
 
     EUROCODE 2 1992-1-1:2004, Fig. 3.8

--- a/structuralcodes/codes/ec2_2023/_section5_materials.py
+++ b/structuralcodes/codes/ec2_2023/_section5_materials.py
@@ -570,7 +570,7 @@ def k_tc(t_ref: float, t0: float, strength_dev_class: str) -> float:
     return 0.85
 
 
-def fcd(fck: float, _eta_cc: float, _k_tc: float, gamma_C: float) -> float:
+def fcd(fck: float, _eta_cc: float, _k_tc: float, gamma_c: float) -> float:
     """Computes the value of the design compressive strength of concrete.
 
     EN 1992-1-1:2023, Eq. (5.3)
@@ -583,7 +583,7 @@ def fcd(fck: float, _eta_cc: float, _k_tc: float, gamma_C: float) -> float:
             member
         _k_tc (float): factor for taking into consideration high
             sustained loads and of time of loading
-        gamma_C (float): partial factor of concrete
+        gamma_c (float): partial factor of concrete
 
     Returns:
         float: the design compressive strength of concrete in MPa
@@ -591,16 +591,16 @@ def fcd(fck: float, _eta_cc: float, _k_tc: float, gamma_C: float) -> float:
     Raises:
         ValueError: if fck is less than 12 MPa
         ValueError if _etc_cc is not between 0 and 1
-        ValueError: if gamma_C is less or equal to 0
+        ValueError: if gamma_c is less or equal to 0
     """
     if fck < 12:
         raise ValueError(f'fck={fck} must be larger or equal than 12 MPa')
     if _eta_cc < 0 or _eta_cc > 1:
         raise ValueError(f'_eta_cc={_eta_cc} must be between 0 and 1')
-    if gamma_C <= 0:
-        raise ValueError(f'gamma_C={gamma_C} must be larger than 0')
+    if gamma_c <= 0:
+        raise ValueError(f'gamma_c={gamma_c} must be larger than 0')
 
-    return _eta_cc * _k_tc * fck / gamma_C
+    return _eta_cc * _k_tc * fck / gamma_c
 
 
 def k_tt(t_ref: float, strength_dev_class: str) -> float:
@@ -642,7 +642,7 @@ def k_tt(t_ref: float, strength_dev_class: str) -> float:
     return 0.7
 
 
-def fctd(_fctk_5: float, _k_tt: float, gamma_C: float) -> float:
+def fctd(_fctk_5: float, _k_tt: float, gamma_c: float) -> float:
     """Computes the value of the design tensile strength of concrete.
 
     EN 1992-1-1:2023, Eq. (5.5)
@@ -651,21 +651,21 @@ def fctd(_fctk_5: float, _k_tt: float, gamma_C: float) -> float:
         fctk_5 (float): the 5% mean concrete tensile strength fractile in MPa
         _k_tt (float): the factor for considering the effect of high sustained
             loads and of time of loading on concrete tensile strength
-        gamma_C (float): partial factor of concrete
+        gamma_c (float): partial factor of concrete
 
     Returns:
         float: the design tensile strength of concrete in MPa
 
     Raises:
         ValueError: if fctk_5 is less than 0
-        ValueError: gamma_C is less than 1
+        ValueError: gamma_c is less than 1
     """
     if _fctk_5 < 0:
         raise ValueError(f'fctk_5={_fctk_5} must be larger or equal to 0')
-    if gamma_C < 1:
-        raise ValueError(f'gamma_C={gamma_C} must be larger or equal to 1')
+    if gamma_c < 1:
+        raise ValueError(f'gamma_c={gamma_c} must be larger or equal to 1')
 
-    return _k_tt * _fctk_5 / gamma_C
+    return _k_tt * _fctk_5 / gamma_c
 
 
 def eps_c1(_fcm: float) -> float:

--- a/structuralcodes/codes/ec2_2023/_section5_materials.py
+++ b/structuralcodes/codes/ec2_2023/_section5_materials.py
@@ -873,7 +873,7 @@ def weight_s() -> float:
     return 78.5
 
 
-def fyd(fyk: float, gamma_S: float = 1.15) -> float:
+def fyd(fyk: float, gamma_S: float) -> float:
     """Design value for the yielding stress for welding reinforcing steel.
 
     EN 1992-1-1:2023, Eq (5.11)

--- a/structuralcodes/codes/mc2010/__init__.py
+++ b/structuralcodes/codes/mc2010/__init__.py
@@ -2,7 +2,7 @@
 
 import typing as t
 
-from ._concrete_material_properties import Gf, fcm, fctkmax, fctkmin, fctm
+from ._concrete_material_properties import Gf, fcd, fcm, fctkmax, fctkmin, fctm
 from ._reinforcement_material_properties import fyd, reinforcement_duct_props
 
 __all__ = [
@@ -10,6 +10,7 @@ __all__ = [
     'fctm',
     'fctkmin',
     'fctkmax',
+    'fcd',
     'Gf',
     'fyd',
     'reinforcement_duct_props',

--- a/structuralcodes/codes/mc2010/_concrete_material_properties.py
+++ b/structuralcodes/codes/mc2010/_concrete_material_properties.py
@@ -187,3 +187,20 @@ def E_ci_t(_beta_e: npt.ArrayLike, _E_ci: float) -> np.ndarray:
             time 'time' (not 28 days) in MPa.
     """
     return _beta_e * _E_ci
+
+
+def fcd(fck: float, alpha_cc: float, gamma_c: float) -> float:
+    """The design compressive strength of concrete.
+
+    Defined in fib Model Code 2010 (2013), Eq. 7.2-11.
+
+    Args:
+        fck (float): The characteristic compressive strength in MPa.
+        alpha_cc (float): A factor for considering long-term effects on the
+            strength, and effects that arise from the way the load is applied.
+        gamma_c (float): The partial factor of concrete.
+
+    Returns:
+        float: The design compressive strength of concrete in MPa
+    """
+    return abs(alpha_cc) * abs(fck) / abs(gamma_c)

--- a/structuralcodes/codes/mc2010/_reinforcement_material_properties.py
+++ b/structuralcodes/codes/mc2010/_reinforcement_material_properties.py
@@ -22,7 +22,7 @@ DUCTILITY_CLASSES = {
 }
 
 
-def fyd(fyk: float, gamma_s: float = 1.15) -> float:
+def fyd(fyk: float, gamma_s: float) -> float:
     """Calculate the design value of the reinforcement yield strength.
 
     fib Model Code 2010, Sec. 4.5.2.2.3

--- a/structuralcodes/materials/concrete/__init__.py
+++ b/structuralcodes/materials/concrete/__init__.py
@@ -20,6 +20,7 @@ def create_concrete(
     fck: float,
     name: t.Optional[str] = None,
     density: float = 2400.0,
+    gamma_c: t.Optional[float] = None,
     existing: bool = False,
     design_code: t.Optional[str] = None,
 ) -> t.Optional[Concrete]:
@@ -32,6 +33,7 @@ def create_concrete(
 
     Keyword Args:
         density (float): Density of Concrete in kg/m3 (default: 2400)
+        gamma_c (Optional(float)): The partial factor for concrete.
         existing (bool): Boolean indicating if the concrete is of an
             existing structure (default: False)
         design_code (str): Optional string (default: None) indicating the
@@ -60,5 +62,11 @@ def create_concrete(
 
     # Create the proper concrete object
     if code.__title__ == 'fib Model Code 2010':
-        return ConcreteMC2010(fck, name, density, existing)
+        return ConcreteMC2010(
+            fck=fck,
+            name=name,
+            density=density,
+            gamma_c=gamma_c,
+            existing=existing,
+        )
     return None

--- a/structuralcodes/materials/concrete/_concrete.py
+++ b/structuralcodes/materials/concrete/_concrete.py
@@ -10,6 +10,7 @@ class Concrete(Material):
     """The abstract concrete material."""
 
     _fck: float
+    _gamma_c: t.Optional[float] = None
     _existing: bool
 
     def __init__(
@@ -17,6 +18,7 @@ class Concrete(Material):
         fck: float,
         name: t.Optional[str] = None,
         density: float = 2400,
+        gamma_c: t.Optional[float] = None,
         existing: t.Optional[bool] = False,
     ) -> None:
         """Initializes an abstract concrete material."""
@@ -29,6 +31,7 @@ class Concrete(Material):
                 'Existing concrete feature not implemented yet'
             )
         self._existing = existing
+        self._gamma_c = gamma_c
 
     @property
     def fck(self) -> float:
@@ -45,4 +48,11 @@ class Concrete(Material):
     def _reset_attributes(self):
         """Each concrete should define its own _reset_attributes method
         This is because fck setting, reset the object arguments.
+        """
+
+    @property
+    @abc.abstractmethod
+    def gamma_c(self) -> float:
+        """Each concrete should implement its own getter for the partial factor
+        in order to interact with the globally set national annex.
         """

--- a/structuralcodes/materials/concrete/_concreteEC2_2023.py
+++ b/structuralcodes/materials/concrete/_concreteEC2_2023.py
@@ -204,7 +204,7 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
         """
         eta_cc = ec2_2023.eta_cc(self.fck, fck_ref=fck_ref)
         k_tc = ec2_2023.k_tc(t_ref, t0, self._strength_dev_class)
-        return ec2_2023.fcd(self.fck, eta_cc, k_tc, self._gamma_C)
+        return ec2_2023.fcd(self.fck, eta_cc, k_tc, self.gamma_c)
 
     def fctd(self, t_ref: float = 28) -> float:
         """Computes the value of the design tensile strength of concrete.
@@ -222,7 +222,7 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
         k_tt = ec2_2023.k_tt(
             t_ref=t_ref, strength_dev_class=self._strength_dev_class
         )
-        return ec2_2023.fctd(self.fctk_5, k_tt, self._gamma_C)
+        return ec2_2023.fctd(self.fctk_5, k_tt, self.gamma_c)
 
     @property
     def eps_c1(self) -> float:

--- a/structuralcodes/materials/concrete/_concreteEC2_2023.py
+++ b/structuralcodes/materials/concrete/_concreteEC2_2023.py
@@ -13,7 +13,6 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
     # Inherent concrete properties
     _kE: t.Optional[float] = None  # noqa: N815
     _strength_dev_class: t.Optional[str] = None
-    _gamma_C: t.Optional[float] = None  # noqa: N815
 
     # Computed attributes
     _fcm: t.Optional[float] = None
@@ -31,7 +30,7 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
         density: float = 2400.0,
         kE: float = 9500,
         strength_dev_class: str = 'CN',
-        gamma_C: float = 1.5,
+        gamma_c: t.Optional[float] = None,
         existing: bool = False,
     ):
         """Initializes a new instance of Concrete for EC2 2023.
@@ -46,7 +45,7 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
             kE (float): coefficient relating aggregates.
             strength_dev_class (str, optional): default is CN.
                 Possible values: CS, CN, CR, slow, normal or rapid
-            gamma_C (float, optional): partial factor of concrete
+            gamma_c (float, optional): partial factor of concrete
                 (default is 1.5)
             existing (bool, optional): The material is of an existing structure
                 (default: False)
@@ -64,17 +63,20 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
             )
 
         # Check for valid security coeff
-        if gamma_C <= 0:
+        if gamma_c is not None and gamma_c <= 0:
             raise ValueError(
-                f'gamma_C cannot be less than zero. Current: {gamma_C}'
+                f'gamma_c cannot be less than zero. Current: {gamma_c}'
             )
 
         super().__init__(
-            fck=fck, name=name, density=density, existing=existing
+            fck=fck,
+            name=name,
+            density=density,
+            existing=existing,
+            gamma_c=gamma_c,
         )
         self._kE = kE
         self._strength_dev_class = strength_dev_class
-        self._gamma_C = gamma_C
 
     def _reset_attributes(self):
         """Reset computed properties."""
@@ -259,3 +261,10 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
         return ec2_2023.sigma_c(
             self.Ecm, self.fcm, eps_c, self.eps_c1, self.eps_cu1
         )
+
+    @property
+    def gamma_c(self) -> float:
+        """The partial factor for concrete."""
+        # Here we should implement the interaction with the globally set
+        # national annex. For now, we simply return the default value.
+        return self._gamma_c or 1.5

--- a/structuralcodes/materials/concrete/_concreteMC2010.py
+++ b/structuralcodes/materials/concrete/_concreteMC2010.py
@@ -178,3 +178,16 @@ class ConcreteMC2010(Concrete):
     def gamma_c(self) -> float:
         """The partial factor for concrete."""
         return self._gamma_c or 1.5
+
+    def fcd(self, alpha_cc: float) -> float:
+        """Calculate the design compressive strength.
+
+        Args:
+            alpha_cc (float): A factor for considering long-term effects on the
+                strength, and effects that arise from the way the load is
+                applied.
+
+        Returns:
+            float: The design compressive strength of concrete in MPa
+        """
+        return mc2010.fcd(self.fck, alpha_cc=alpha_cc, gamma_c=self.gamma_c)

--- a/structuralcodes/materials/concrete/_concreteMC2010.py
+++ b/structuralcodes/materials/concrete/_concreteMC2010.py
@@ -22,6 +22,7 @@ class ConcreteMC2010(Concrete):
         fck: float,
         name: t.Optional[str] = None,
         density: float = 2400.0,
+        gamma_c: t.Optional[float] = None,
         existing: bool = False,
     ):
         """Initializes a new instance of Concrete for MC 2010.
@@ -31,15 +32,20 @@ class ConcreteMC2010(Concrete):
                 existing.
 
         Keyword Args:
-            name (str): A descriptive name for concrete
-            density (float): Density of material in kg/m3 (default: 2400)
+            name (Optional(str)): A descriptive name for concrete.
+            density (float): Density of material in kg/m3 (default: 2400).
+            gamma_c (Optional(float)): The partial factor for concrete.
             existing (bool): The material is of an existing structure
-                (default: False)
+                (default: False).
         """
         if name is None:
             name = f'C{round(fck):d}'
         super().__init__(
-            fck=fck, name=name, density=density, existing=existing
+            fck=fck,
+            name=name,
+            density=density,
+            existing=existing,
+            gamma_c=gamma_c,
         )
 
     def _reset_attributes(self):
@@ -167,3 +173,8 @@ class ConcreteMC2010(Concrete):
             value (float): the value of Gf in N/m
         """
         self._Gf = abs(value)
+
+    @property
+    def gamma_c(self) -> float:
+        """The partial factor for concrete."""
+        return self._gamma_c or 1.5

--- a/structuralcodes/materials/reinforcement/__init__.py
+++ b/structuralcodes/materials/reinforcement/__init__.py
@@ -29,6 +29,7 @@ def create_reinforcement(
     Es: float,
     ftk: float,
     epsuk: float,
+    gamma_s: t.Optional[float] = None,
     name: t.Optional[str] = None,
     density: float = 7850,
     design_code: t.Optional[str] = None,
@@ -43,6 +44,7 @@ def create_reinforcement(
         epsuk (float): The characteristik strain at the ultimate stress level.
 
     Keyword Args:
+        gamma_s (Optional(float)): The partial factor for reinforcement.
         density (float): Density of the material in kg/m3 (default: 7850)
         design_code (str): Optional string (default: None) indicating the
             desired standard. If None (default) the globally used design
@@ -77,5 +79,6 @@ def create_reinforcement(
             density=density,
             ftk=ftk,
             epsuk=epsuk,
+            gamma_s=gamma_s,
         )
     return None

--- a/structuralcodes/materials/reinforcement/_reinforcement.py
+++ b/structuralcodes/materials/reinforcement/_reinforcement.py
@@ -1,5 +1,6 @@
 """Core implementation of the reinforcement material."""
 
+import abc
 import typing as t
 
 from structuralcodes.core.base import Material
@@ -12,6 +13,7 @@ class Reinforcement(Material):
     _Es: float
     _ftk: float
     _epsuk: float
+    _gamma_s: t.Optional[float] = None
 
     def __init__(
         self,
@@ -20,6 +22,7 @@ class Reinforcement(Material):
         density: float,
         ftk: float,
         epsuk: float,
+        gamma_s: t.Optional[float] = None,
         name: t.Optional[str] = None,
     ) -> None:
         """Initializes an abstract reinforcement material."""
@@ -30,6 +33,7 @@ class Reinforcement(Material):
         self._Es = abs(Es)
         self._ftk = abs(ftk)
         self._epsuk = abs(epsuk)
+        self._gamma_s = gamma_s
 
     @property
     def fyk(self) -> float:
@@ -70,3 +74,10 @@ class Reinforcement(Material):
     def epsuk(self, epsuk: float) -> None:
         """Setter for epsuk."""
         self._epsuk = abs(epsuk)
+
+    @property
+    @abc.abstractmethod
+    def gamma_s(self) -> float:
+        """Each reinforcement should implement its own getter for the partial
+        factor in order to interact with the globally set national annex.
+        """

--- a/structuralcodes/materials/reinforcement/_reinforcementEC2_2004.py
+++ b/structuralcodes/materials/reinforcement/_reinforcementEC2_2004.py
@@ -47,9 +47,9 @@ class ReinforcementEC2_2004(Reinforcement):  # noqa: N801
             gamma_s=gamma_s,
         )
 
-    @property
     def fyd(self) -> float:
         """The design yield strength."""
+        return ec2_2004.fyd(self.fyk, self.gamma_s)
 
     @property
     def gamma_s(self) -> float:

--- a/structuralcodes/materials/reinforcement/_reinforcementEC2_2004.py
+++ b/structuralcodes/materials/reinforcement/_reinforcementEC2_2004.py
@@ -16,6 +16,7 @@ class ReinforcementEC2_2004(Reinforcement):  # noqa: N801
         Es: float,
         ftk: float,
         epsuk: float,
+        gamma_s: t.Optional[float] = None,
         name: t.Optional[str] = None,
         density: float = 7850.0,
     ):
@@ -27,6 +28,7 @@ class ReinforcementEC2_2004(Reinforcement):  # noqa: N801
             ftk (float): Characteristic ultimate strength in MPa.
             epsuk (float): The characteristik strain at the ultimate stress
                 level.
+            gamma_s (Optional(float)): The partial factor for reinforcement.
 
         Keyword Args:
             name (str): A descriptive name for the reinforcement.
@@ -42,9 +44,16 @@ class ReinforcementEC2_2004(Reinforcement):  # noqa: N801
             density=density,
             ftk=ftk,
             epsuk=epsuk,
+            gamma_s=gamma_s,
         )
 
     @property
     def fyd(self) -> float:
         """The design yield strength."""
-        return ec2_2004.fyd(self.fyk)
+
+    @property
+    def gamma_s(self) -> float:
+        """The partial factor for reinforcement."""
+        # Here we should implement the interaction with the globally set
+        # national annex. For now, we simply return the default value.
+        return self._gamma_s or 1.15

--- a/structuralcodes/materials/reinforcement/_reinforcementEC2_2023.py
+++ b/structuralcodes/materials/reinforcement/_reinforcementEC2_2023.py
@@ -46,9 +46,9 @@ class ReinforcementEC2_2023(Reinforcement):  # noqa: N801
             gamma_s=gamma_s,
         )
 
-    @property
     def fyd(self) -> float:
         """The design yield strength."""
+        return ec2_2023.fyd(self.fyk, self.gamma_s)
 
     @property
     def gamma_s(self) -> float:

--- a/structuralcodes/materials/reinforcement/_reinforcementEC2_2023.py
+++ b/structuralcodes/materials/reinforcement/_reinforcementEC2_2023.py
@@ -16,6 +16,7 @@ class ReinforcementEC2_2023(Reinforcement):  # noqa: N801
         Es: float,
         ftk: float,
         epsuk: float,
+        gamma_s: t.Optional[float] = None,
         name: t.Optional[str] = None,
         density: float = 7850.0,
     ):
@@ -27,6 +28,7 @@ class ReinforcementEC2_2023(Reinforcement):  # noqa: N801
             ftk (float): Characteristic ultimate strength in MPa.
             epsuk (float): The characteristik strain at the ultimate stress
                 level.
+            gamma_s (Optional(float)): The partial factor for reinforcement.
 
         Keyword Args:
             name (str): A descriptive name for the reinforcement.
@@ -41,9 +43,16 @@ class ReinforcementEC2_2023(Reinforcement):  # noqa: N801
             density=density,
             ftk=ftk,
             epsuk=epsuk,
+            gamma_s=gamma_s,
         )
 
     @property
     def fyd(self) -> float:
         """The design yield strength."""
-        return ec2_2023.fyd(self.fyk)
+
+    @property
+    def gamma_s(self) -> float:
+        """The partial factor for reinforcement."""
+        # Here we should implement the interaction with the globally set
+        # national annex. For now, we simply return the default value.
+        return self._gamma_s or 1.15

--- a/structuralcodes/materials/reinforcement/_reinforcementMC2010.py
+++ b/structuralcodes/materials/reinforcement/_reinforcementMC2010.py
@@ -46,9 +46,9 @@ class ReinforcementMC2010(Reinforcement):
             gamma_s=gamma_s,
         )
 
-    @property
     def fyd(self) -> float:
         """The design yield strength."""
+        return mc2010.fyd(self.fyk, self.gamma_s)
 
     @property
     def gamma_s(self) -> float:

--- a/structuralcodes/materials/reinforcement/_reinforcementMC2010.py
+++ b/structuralcodes/materials/reinforcement/_reinforcementMC2010.py
@@ -16,6 +16,7 @@ class ReinforcementMC2010(Reinforcement):
         Es: float,
         ftk: float,
         epsuk: float,
+        gamma_s: t.Optional[float] = None,
         name: t.Optional[str] = None,
         density: float = 7850.0,
     ):
@@ -27,6 +28,7 @@ class ReinforcementMC2010(Reinforcement):
             ftk (float): Characteristic ultimate strength in MPa.
             epsuk (float): The characteristik strain at the ultimate stress
                 level.
+            gamma_s (Optional(float)): The partial factor for reinforcement.
 
         Keyword Args:
             name (str): A descriptive name for the reinforcement.
@@ -41,9 +43,14 @@ class ReinforcementMC2010(Reinforcement):
             density=density,
             ftk=ftk,
             epsuk=epsuk,
+            gamma_s=gamma_s,
         )
 
     @property
     def fyd(self) -> float:
         """The design yield strength."""
-        return mc2010.fyd(self.fyk)
+
+    @property
+    def gamma_s(self) -> float:
+        """The partial factor for reinforcement."""
+        return self._gamma_s or 1.15

--- a/tests/test_ec2_2023/test_concrete_ec2_2023.py
+++ b/tests/test_ec2_2023/test_concrete_ec2_2023.py
@@ -20,7 +20,7 @@ def test_initialization(default_concrete):
     assert default_concrete.density == 2400.0
     assert default_concrete._kE == 9500
     assert default_concrete._strength_dev_class == 'CN'
-    assert default_concrete._gamma_C == 1.5
+    assert default_concrete.gamma_c == 1.5
 
 
 def test_invalid_strength_dev_class():
@@ -29,10 +29,10 @@ def test_invalid_strength_dev_class():
         ConcreteEC2_2023(fck=30, strength_dev_class='invalid_class')
 
 
-def test_invalid_gamma_C():
+def test_invalid_gamma_c():
     """Test for invalid sec. coefficient."""
     with pytest.raises(ValueError):
-        ConcreteEC2_2023(fck=30, gamma_C=-1)
+        ConcreteEC2_2023(fck=30, gamma_c=-1)
 
 
 def test_fcm_property(default_concrete):

--- a/tests/test_ec2_2023/test_ec2_2023_section5_materials.py
+++ b/tests/test_ec2_2023/test_ec2_2023_section5_materials.py
@@ -305,24 +305,24 @@ def test_k_tc_raises_errors(t_ref, t0, concrete_class):
 
 
 @pytest.mark.parametrize(
-    'fck, eta_cc, k_tc, gamma_C, expected',
+    'fck, eta_cc, k_tc, gamma_c, expected',
     [
         (40, 0.9, 0.85, 1.35, 22.6666666666667),
         (35, 1, 1, 1.5, 23.3333333333333),
         (50, 0.85, 0.85, 1.4, 25.8035714285714),
     ],
 )
-def test_fcd(fck, eta_cc, k_tc, gamma_C, expected):
+def test_fcd(fck, eta_cc, k_tc, gamma_c, expected):
     """Test fcd function."""
     assert math.isclose(
-        _section5_materials.fcd(fck, eta_cc, k_tc, gamma_C),
+        _section5_materials.fcd(fck, eta_cc, k_tc, gamma_c),
         expected,
         rel_tol=10e-5,
     )
 
 
 @pytest.mark.parametrize(
-    'fck, eta_cc, k_tc, gamma_C',
+    'fck, eta_cc, k_tc, gamma_c',
     [
         (-10, 0.5, 0.85, 1.5),
         (40, -1, 0.85, 1.5),
@@ -330,10 +330,10 @@ def test_fcd(fck, eta_cc, k_tc, gamma_C, expected):
         (40, 0.9, 1.0, -2),
     ],
 )
-def test_fcd_raises_errors(fck, eta_cc, k_tc, gamma_C):
+def test_fcd_raises_errors(fck, eta_cc, k_tc, gamma_c):
     """Test fcd function raises errors."""
     with pytest.raises(ValueError):
-        _section5_materials.fcd(fck, eta_cc, k_tc, gamma_C)
+        _section5_materials.fcd(fck, eta_cc, k_tc, gamma_c)
 
 
 @pytest.mark.parametrize(
@@ -371,26 +371,26 @@ def test_k_tt_raises_errors(t_ref, concrete_class):
 
 
 @pytest.mark.parametrize(
-    'fctk_5, k_tt, gamma_C', [(-20, 0.8, 1.5), (40, 0.7, -1)]
+    'fctk_5, k_tt, gamma_c', [(-20, 0.8, 1.5), (40, 0.7, -1)]
 )
-def test_fctd_raises_errors(fctk_5, k_tt, gamma_C):
+def test_fctd_raises_errors(fctk_5, k_tt, gamma_c):
     """Test fctd raises errors."""
     with pytest.raises(ValueError):
-        _section5_materials.fctd(fctk_5, k_tt, gamma_C)
+        _section5_materials.fctd(fctk_5, k_tt, gamma_c)
 
 
 @pytest.mark.parametrize(
-    'fctk_5, k_tt, gamma_C, expected',
+    'fctk_5, k_tt, gamma_c, expected',
     [
         (2, 0.7, 1.5, 0.933333333333333),
         (3, 0.8, 1.25, 1.92),
         (1.8, 0.7, 1.3, 0.969230769230769),
     ],
 )
-def test_fctd(fctk_5, k_tt, gamma_C, expected):
+def test_fctd(fctk_5, k_tt, gamma_c, expected):
     """Test fctd."""
     assert math.isclose(
-        _section5_materials.fctd(fctk_5, k_tt, gamma_C),
+        _section5_materials.fctd(fctk_5, k_tt, gamma_c),
         expected,
         rel_tol=10e-5,
     )

--- a/tests/test_materials/test_reinforcements.py
+++ b/tests/test_materials/test_reinforcements.py
@@ -31,7 +31,7 @@ def test_reinforcements(reinforcement_material):
     # Assert
     assert reinf.fyk == fyk
     assert reinf.Es == Es
-    assert math.isclose(reinf.fyd, fyk / 1.15)
+    assert math.isclose(reinf.fyd(), fyk / 1.15)
 
     # Set new values
     reinf.fyk = 1.05 * reinf.fyk

--- a/tests/test_mc2010/test_concrete_mc2010.py
+++ b/tests/test_mc2010/test_concrete_mc2010.py
@@ -296,3 +296,32 @@ def test_Gf_setter(test_input, expected):
     c.Gf = expected
 
     assert math.isclose(c.Gf, expected)
+
+
+def test_gamma_c():
+    """Test the gamma_c property."""
+    # Arrange
+    concrete = ConcreteMC2010(45)
+
+    # Assert
+    assert math.isclose(concrete.gamma_c, 1.5)
+
+
+@pytest.mark.parametrize(
+    'fck, alpha_cc, expected',
+    [
+        (35, 0.85, 19.8333),
+        (45, 0.85, 25.5),
+        (90, 0.85, 51.0),
+    ],
+)
+def test_fcd(fck, alpha_cc, expected):
+    """Test calculating the design compressive strength."""
+    # Arrange
+    concrete = ConcreteMC2010(fck)
+
+    # Act
+    fcd = concrete.fcd(alpha_cc=alpha_cc)
+
+    # Assert
+    assert math.isclose(fcd, expected, rel_tol=10e-5)

--- a/tests/test_mc2010/test_mc2010_material_properties.py
+++ b/tests/test_mc2010/test_mc2010_material_properties.py
@@ -209,3 +209,20 @@ def test_E_ci_t(_beta_e, _E_ci, expected):
         expected,
         rtol=1e-5,
     )
+
+
+@pytest.mark.parametrize(
+    'fck, alpha_cc, gamma_c, expected',
+    [
+        (35, 0.85, 1.5, 19.8333),
+        (45, 0.85, 1.5, 25.5),
+        (90, 0.85, 1.5, 51.0),
+    ],
+)
+def test_fcd(fck, alpha_cc, gamma_c, expected):
+    """Test fcd function."""
+    assert math.isclose(
+        _concrete_material_properties.fcd(fck, alpha_cc, gamma_c),
+        expected,
+        rel_tol=10e-5,
+    )


### PR DESCRIPTION
An attempt to unify the treatment of partial factors between materials and codes. The idea is the following:

- For the `Concrete` class we implement an abstract property `gamma_c`. Similar with `gamma_s` for the `Reinforcement` class.
- `gamma_c` is an optional argument to the constructor of `Concrete`, which sets an internal attribute `_gamma_c`. Similar for the `Reinforcement`.
- The concrete implementation of the `gamma_c` property should either return the value of `_gamma_c` if it is not `None`, or return the value associated with the globally set national annex. In the current implementation, lacking an implementation of the national annexes, the concrete implementations simply return the default values.
- Note that the functions for calculating e.g. `fcd` and `fyd` do not have default values for `gamma_c` or `gamma_s`, and that the related methods on the `Concrete` and `Reinforcement` classes get the value of `gamma_c` and `gamma_s` from the related attribute.

Note that this is similar to the current implementation of `ConcreteEC2_2023`, but with the addition of creating the `property` for `gamma_c` which allows us to connect to the national annexes when the getter is called.

We can also consider using this setup for handling other NDPs.