### PR TITLE
feat: Add Sargin Constitutive Law to Constitutive laws

### DIFF
--- a/structuralcodes/core/base.py
+++ b/structuralcodes/core/base.py
@@ -4,6 +4,8 @@ import abc
 import typing as t
 import warnings
 
+import numpy as np
+
 import structuralcodes.core._section_results as s_res
 
 
@@ -102,9 +104,50 @@ class ConstitutiveLaw(abc.ABC):
     def __marin__(self, **kwargs):
         """Function for getting the strain limits and coefficients
         for marin integration.
+
+        By default the law is discretized as a piecewise linear
+        function. Then marin coefficients are computed based on this
+        discretization.
         """
-        del kwargs
-        raise NotImplementedError
+
+        # Discretize the constitutive law in a "smart way"
+        def find_x_lim(x, y):
+            # Find the index where x changes from negative to non-negative
+            zero_crossing_index = np.argmax(x >= 0)
+
+            # Check if there are non-zero values for x > 0
+            if np.any(y[zero_crossing_index:] != 0):
+                # Find the last non-zero index for x > 0
+                non_zero_indices = np.nonzero(y[zero_crossing_index:])[0]
+                x_lim_index = zero_crossing_index + non_zero_indices[-1]
+                return x[x_lim_index]
+            # All values are zero for x > 0
+            return None
+
+        eps_max, eps_min = self.get_ultimate_strain()
+        if eps_max > 1:
+            eps_max = 1
+        eps = np.linspace(eps_min, eps_max, 100000)
+        sig = self.get_stress(eps)
+        sig[(sig > 0) & (sig < np.max(sig) * 1e-6)] = 0
+        eps_lim = find_x_lim(eps, sig)
+        # Now discretize the function in 10 steps for positive and 10 steps for
+        # negative part
+        if eps_lim is None:
+            eps = np.linspace(eps_min, 0, 10)
+        else:
+            eps = np.concatenate(
+                (
+                    np.linspace(eps_min, 0, 10, endpoint=False),
+                    np.linspace(0, eps_lim, 10),
+                )
+            )
+
+        sig = self.get_stress(eps)
+        from structuralcodes.materials.constitutive_laws import UserDefined
+
+        # Return Marin coefficients for linearized version
+        return UserDefined(eps, sig).__marin__(**kwargs)
 
     def get_secant(self, eps: float) -> float:
         """Method to return the

--- a/structuralcodes/core/base.py
+++ b/structuralcodes/core/base.py
@@ -130,18 +130,21 @@ class ConstitutiveLaw(abc.ABC):
         sig[(sig < np.max(sig) * 1e-6)] = 0
         eps_lim = find_x_lim(eps, sig)
         # Now discretize the function in 10 steps for positive part
-        eps_pos = [] if eps_lim is None else np.linspace(0, eps_lim, 10)
+        eps_pos = (
+            np.linspace(0, -eps_min, 1)
+            if eps_lim is None
+            else np.linspace(0, eps_lim, 10)
+        )
         # Analise negative branch
         eps = np.linspace(0, eps_min, 10000)
         sig = -self.get_stress(eps)
         sig[(sig < np.max(sig) * 1e-6)] = 0
         eps_lim = find_x_lim(-eps, sig)
         # Now discretize the function in 10 steps for negative part
-        endpoint = bool(eps_pos == [])
         eps_neg = (
-            []
+            np.linspace(eps_min, 0, 1, endpoint=False)
             if eps_lim is None
-            else np.linspace(-eps_lim, 0, 10, endpoint=endpoint)
+            else np.linspace(-eps_lim, 0, 10, endpoint=False)
         )
 
         eps = np.concatenate((eps_neg, eps_pos))

--- a/structuralcodes/materials/constitutive_laws.py
+++ b/structuralcodes/materials/constitutive_laws.py
@@ -200,6 +200,7 @@ class ElasticPlastic(ConstitutiveLaw):
 
 class ParabolaRectangle(ConstitutiveLaw):
     """Class for parabola rectangle constitutive law.
+
     The stresses and strains are assumed negative in compression and positive
     in tension.
     """
@@ -304,6 +305,7 @@ class ParabolaRectangle(ConstitutiveLaw):
 
 class Sargin(ConstitutiveLaw):
     """Class for Sargin constitutive law.
+
     The stresses and strains are assumed negative in compression
     and positive in tension.
     """
@@ -384,7 +386,8 @@ class Sargin(ConstitutiveLaw):
 
 
 class UserDefined(ConstitutiveLaw):
-    """Class for a user defined constitutive law
+    """Class for a user defined constitutive law.
+
     The curve is defined with positive and optionally negative
     values. After the last value, the stress can go to zero to simulate
     failure (default), or be mantained constante, or the last tanget or

--- a/structuralcodes/materials/constitutive_laws.py
+++ b/structuralcodes/materials/constitutive_laws.py
@@ -14,7 +14,7 @@ class Elastic(ConstitutiveLaw):
     __materials__: t.Tuple[str] = (
         'concrete',
         'steel',
-        'reinforcement',
+        'rebars',
     )
 
     def __init__(self, E: float, name: t.Optional[str] = None) -> None:
@@ -105,7 +105,7 @@ class ElasticPlastic(ConstitutiveLaw):
 
     __materials__: t.Tuple[str] = (
         'steel',
-        'reinforcement',
+        'rebars',
     )
 
     def __init__(
@@ -392,7 +392,7 @@ class UserDefined(ConstitutiveLaw):
     controls this behavior.
     """
 
-    __materials__: t.Tuple[str] = ('concrete', 'steel', 'reinforcement')
+    __materials__: t.Tuple[str] = ('concrete', 'steel', 'rebars')
 
     def __init__(
         self,

--- a/structuralcodes/materials/constitutive_laws.py
+++ b/structuralcodes/materials/constitutive_laws.py
@@ -14,7 +14,7 @@ class Elastic(ConstitutiveLaw):
     __materials__: t.Tuple[str] = (
         'concrete',
         'steel',
-        'rebars',
+        'reinforcement',
     )
 
     def __init__(self, E: float, name: t.Optional[str] = None) -> None:
@@ -105,7 +105,7 @@ class ElasticPlastic(ConstitutiveLaw):
 
     __materials__: t.Tuple[str] = (
         'steel',
-        'rebars',
+        'reinforcement',
     )
 
     def __init__(
@@ -214,7 +214,7 @@ class ParabolaRectangle(ConstitutiveLaw):
         n: float = 2.0,
         name: t.Optional[str] = None,
     ) -> None:
-        """Initialize an Elastic-Plastic Material.
+        """Initialize a Parabola-Rectangle Material.
 
         Arguments:
         fc: (float) the strength of concrete in compression
@@ -302,6 +302,87 @@ class ParabolaRectangle(ConstitutiveLaw):
         return (100, self._eps_u)
 
 
+class Sargin(ConstitutiveLaw):
+    """Class for Sargin constitutive law.
+    The stresses and strains are assumed negative in compression
+    and positive in tension.
+    """
+
+    __materials__: t.Tuple[str] = ('concrete',)
+
+    def __init__(
+        self,
+        fc: float,
+        eps_c1: float = -0.0023,
+        eps_cu1: float = -0.0035,
+        k: float = 2.04,
+        name: t.Optional[str] = None,
+    ) -> None:
+        """Initialize a Sargin Material.
+
+        Arguments:
+            fc: (float) the strength of concrete in compression
+            eps_c1: (float) peak strain of concrete in compression
+                optional, default value = -0.0023
+            eps_u: (float) ultimate strain of concrete in compression
+                optional, default value = -0.0035
+            k: (float) plasticity numberm, default value = 2.04
+            name: (str) a name for the constitutive law,
+
+        Raises:
+            ValueError: if k is less or equal to 0
+        Notes:
+            if positive values are input for fc, eps_c1 and eps_cu1
+            are input, they will be assumed negative.
+        """
+        name = name if name is not None else 'ParabolaRectangleLaw'
+        super().__init__(name=name)
+        self._fc = -abs(fc)
+        self._eps_c1 = -abs(eps_c1)
+        self._eps_cu1 = -abs(eps_cu1)
+        self._k = k
+
+    def get_stress(self, eps: float) -> float:
+        """Return the stress given the strain."""
+        eps = np.atleast_1d(np.asarray(eps))
+        # Polynomial branch
+        eta = eps / self._eps_c1
+
+        sig = self._fc * (self._k * eta - eta**2) / (1 + (self._k - 2) * eta)
+
+        # Elsewhere stress is 0.0
+        sig[eps < self._eps_cu1] = 0.0
+        sig[eps > 0] = 0.0
+
+        return sig
+
+    def get_tangent(self, eps: ArrayLike) -> ArrayLike:
+        """Return the tangent given strain."""
+        eps = np.atleast_1d(np.asarray(eps))
+        # polynomial branch
+        eta = eps / self._eps_c1
+
+        tangent = (
+            self._fc
+            / self._eps_c1
+            * ((2 - self._k) * eta**2 - 2 * eta + self._k)
+            / (1 + (self._k - 2) * eta) ** 2
+        )
+        # Elsewhere tangent is zero
+        tangent[eps < self._eps_cu1] = 0.0
+        tangent[eps > 0] = 0.0
+
+        return tangent
+
+    def get_ultimate_strain(
+        self, yielding: bool = False
+    ) -> t.Tuple[float, float]:
+        """Return the ultimate strain (positive and negative)."""
+        if yielding:
+            return (100, self._eps_c1)
+        return (100, self._eps_cu1)
+
+
 class UserDefined(ConstitutiveLaw):
     """Class for a user defined constitutive law
     The curve is defined with positive and optionally negative
@@ -311,7 +392,7 @@ class UserDefined(ConstitutiveLaw):
     controls this behavior.
     """
 
-    __materials__: t.Tuple[str] = ('concrete', 'steel', 'rebars')
+    __materials__: t.Tuple[str] = ('concrete', 'steel', 'reinforcement')
 
     def __init__(
         self,

--- a/structuralcodes/materials/constitutive_laws.py
+++ b/structuralcodes/materials/constitutive_laws.py
@@ -24,7 +24,7 @@ class Elastic(ConstitutiveLaw):
         self._E = E
         self._eps_su = None
 
-    def get_stress(self, eps: ArrayLike) -> float:
+    def get_stress(self, eps: ArrayLike) -> ArrayLike:
         """Return stress given strain."""
         eps = np.asarray(eps)
         return self._E * eps
@@ -344,7 +344,7 @@ class Sargin(ConstitutiveLaw):
         self._eps_cu1 = -abs(eps_cu1)
         self._k = k
 
-    def get_stress(self, eps: float) -> float:
+    def get_stress(self, eps: ArrayLike) -> ArrayLike:
         """Return the stress given the strain."""
         eps = np.atleast_1d(np.asarray(eps))
         # Polynomial branch

--- a/tests/test_core/test_constitutive_laws.py
+++ b/tests/test_core/test_constitutive_laws.py
@@ -373,13 +373,23 @@ def test_sargin(fc, eps_c1, eps_cu1, k):
 
     eps = np.linspace(0, eps_cu1, 20)
 
-    # compute stresses expected
+    # compute expected
     sig_expected = (
         fc
         * (k * eps / eps_c1 - (eps / eps_c1) ** 2)
         / (1 + (k - 2) * eps / eps_c1)
     )
+    tan_expected = (
+        fc
+        / eps_c1
+        * ((2 - k) * (eps / eps_c1) ** 2 - 2 * (eps / eps_c1) + k)
+        / (1 + (k - 2) * eps / eps_c1) ** 2
+    )
 
+    # compute from Sargin
     sig_computed = law.get_stress(eps)
+    tan_computed = law.get_tangent(eps)
 
+    # Compare the two
     assert_allclose(sig_computed, sig_expected)
+    assert_allclose(tan_computed, tan_expected)

--- a/tests/test_core/test_constitutive_laws.py
+++ b/tests/test_core/test_constitutive_laws.py
@@ -393,3 +393,12 @@ def test_sargin(fc, eps_c1, eps_cu1, k):
     # Compare the two
     assert_allclose(sig_computed, sig_expected)
     assert_allclose(tan_computed, tan_expected)
+
+    # Test getting ultimate strain
+    eps_max, eps_min = law.get_ultimate_strain()
+    assert math.isclose(eps_min, eps_cu1)
+    assert math.isclose(eps_max, 100)
+
+    eps_max, eps_min = law.get_ultimate_strain(yielding=True)
+    assert math.isclose(eps_min, eps_c1)
+    assert math.isclose(eps_max, 100)

--- a/tests/test_core/test_constitutive_laws.py
+++ b/tests/test_core/test_constitutive_laws.py
@@ -4,11 +4,13 @@ import math
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from structuralcodes.materials.constitutive_laws import (
     Elastic,
     ElasticPlastic,
     ParabolaRectangle,
+    Sargin,
     UserDefined,
 )
 
@@ -336,3 +338,48 @@ def test_userdefined_set_ultimate_strain_tuple_error(E, fy, eps_su):
     material = UserDefined(x=x, y=y)
     with pytest.raises(ValueError):
         material.set_ultimate_strain(eps_su)
+
+
+@pytest.mark.parametrize(
+    'fc, eps_c1, eps_cu1, k',
+    [
+        (-12, -1.9e-3, -3.5e-3, 2.44),
+        (-16, -2.0e-3, -3.5e-3, 2.36),
+        (-20, -2.1e-3, -3.5e-3, 2.28),
+        (-25, -2.2e-3, -3.5e-3, 2.15),
+        (-30, -2.3e-3, -3.5e-3, 2.04),
+        (
+            -35,
+            -2.3e-3,
+            -3.5e-3,
+            1.92,
+        ),
+        (-40, -2.4e-3, -3.5e-3, 1.82),
+        (-45, -2.5e-3, -3.5e-3, 1.74),
+        (-50, -2.6e-3, -3.4e-3, 1.66),
+        (-55, -2.6e-3, -3.4e-3, 1.61),
+        (-60, -2.7e-3, -3.3e-3, 1.55),
+        (-70, -2.7e-3, -3.2e-3, 1.47),
+        (-80, -2.8e-3, -3.1e-3, 1.41),
+        (-90, -2.9e-3, -3.0e-3, 1.36),
+        (-100, -3.0e-3, -3.0e-3, 1.32),
+        (-110, -3.0e-3, -3.0e-3, 1.24),
+        (-120, -3.0e-3, -3.0e-3, 1.18),
+    ],
+)
+def test_sargin(fc, eps_c1, eps_cu1, k):
+    """Test Sargin material."""
+    law = Sargin(fc=fc, eps_c1=eps_c1, eps_cu1=eps_cu1, k=k)
+
+    eps = np.linspace(0, eps_cu1, 20)
+
+    # compute stresses expected
+    sig_expected = (
+        fc
+        * (k * eps / eps_c1 - (eps / eps_c1) ** 2)
+        / (1 + (k - 2) * eps / eps_c1)
+    )
+
+    sig_computed = law.get_stress(eps)
+
+    assert_allclose(sig_computed, sig_expected)

--- a/tests/test_core/test_generic_section.py
+++ b/tests/test_core/test_generic_section.py
@@ -12,6 +12,7 @@ from structuralcodes.materials.concrete import ConcreteMC2010
 from structuralcodes.materials.constitutive_laws import (
     Elastic,
     ElasticPlastic,
+    Sargin,
     UserDefined,
 )
 from structuralcodes.materials.reinforcement import ReinforcementMC2010
@@ -69,6 +70,46 @@ def test_rectangular_section():
     assert math.isclose(
         res_mc_marin.m_y[-1], res_mc_fiber.m_y[-1], rel_tol=1e-2
     )
+
+
+# Test rectangular section with Sargin Model
+def test_rectangular_section_Sargin():
+    """Test rectangular section."""
+    # Create materials to use
+    concrete = ConcreteMC2010(25)
+    steel = ReinforcementMC2010(fyk=450, Es=210000, ftk=450, epsuk=0.0675)
+    # Set a different constitutive law respect to default Parabola-Rectangle
+    # Here we use Sargin law (MC2010 eq 5.1-26) with parameters taken from
+    # MC2010 table 5.1-8
+    concrete.constitutive_law = Sargin(
+        fc=-35, eps_c1=-2.3e-3, eps_cu1=-3.5e-3, k=1.92
+    )
+
+    # The section
+    poly = Polygon(((0, 0), (200, 0), (200, 400), (0, 400)))
+    geo = SurfaceGeometry(poly, concrete)
+    geo = add_reinforcement_line(geo, (40, 40), (160, 40), 16, steel, n=4)
+    geo = add_reinforcement_line(geo, (40, 360), (160, 360), 16, steel, n=4)
+    geo = geo.translate(-100, -200)
+    assert geo.geometries[0].centroid[0] == 0
+    assert geo.geometries[0].centroid[1] == 0
+
+    # Create the section (default Marin integrator)
+    sec = GenericSection(geo)
+
+    assert math.isclose(sec.gross_properties.area, 200 * 400)
+
+    # Compute bending strength
+    res_marin = sec.section_analyzer.calculate_bending_strength(theta=0, n=0)
+
+    # Use fiber integration
+    sec = GenericSection(geo, integrator='Fiber', mesh_size=0.0001)
+    assert math.isclose(sec.gross_properties.area, 200 * 400)
+
+    # Compute bending strength
+    res_fiber = sec.section_analyzer.calculate_bending_strength(theta=0, n=0)
+
+    assert math.isclose(res_marin.m_y, res_fiber.m_y, rel_tol=1e-2)
 
 
 # Test holed section


### PR DESCRIPTION
Sargin Constitutive Law is added to the list of Constitutive laws. 
Methods for getting stress and tangent are implemented.

Method for getting Marin coefficients is not yet implemented.
The problem is that it seems impossible to represent Sargin as a polynomial function.

My proposal is the following:
- in the `__marin__` method convert the function to a piecewise linear function using `UserDefined`. Then use `__marin__` from UserDefined. 
- a further possibility is that the default `__marin__` for base class `ConstitutiveLaw` those this use of `UserDefined` law for defining a piecewise linear function, so all constitutive laws that are implemented from now on will have a free `__marin__` function for estimating coefficients. If one can and wants, it is possible to define `__marin__` for the derived class to obtain a more performant version (e.g. as we have done for parabola-rectangle end elastic-plastic laws)
