### PR TITLE
feat: refine moment curvature

### DIFF
--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -638,6 +638,7 @@ class GenericSectionCalculator(SectionCalculator):
         chi_first: float = 1e-8,
         num_pre_yield: int = 10,
         num_post_yield: int = 10,
+        chi: t.Optional[ArrayLike] = None,
     ) -> s_res.MomentCurvatureResults:
         """Calculates the moment-curvature relation for given inclination of
         n.a. and axial load.
@@ -647,8 +648,16 @@ class GenericSectionCalculator(SectionCalculator):
         n (float, default = 0): axial load applied to the section (+: tension,
             -: compression)
         chi_first (float, default = 1e-8): the first value of the curvature
-        num_pre_yield (int, default = 10): the number of points before yielding
-        num_post_yield (int, default = 10): the number of points after yielding
+        num_pre_yield (int, default = 10): Number of points before yielding.
+            Note that the yield curvature will be at the num_pre_yield-th point
+            in the result array.
+        num_post_yield (int, default = 10): Number of points after yielding
+        chi (Optional[ArrayLike], default = None): An ArrayLike with curvatures
+            to calculate the moment response for. If chi is None, the array is
+            constructed from chi_first, num_pre_yield and num_post_yield. If
+            chi is not None, chi_first, num_pre_yield and num_post_yield are
+            disregarded, and the provided chi is used directly in the
+            calculations.
 
         Return:
         moment_curvature_result (MomentCurvatureResults)
@@ -664,43 +673,52 @@ class GenericSectionCalculator(SectionCalculator):
 
         # Check if the section can carry the axial load
         self.check_axial_load(n=n)
-        # Find ultimate curvature from the strain distribution corresponding
-        # to failure and equilibrium with external axial force
-        strain = self.find_equilibrium_fixed_pivot(rotated_geom, n)
-        chi_ultimate = strain[1]
-        # Find the yielding curvature
-        strain = self.find_equilibrium_fixed_pivot(
-            rotated_geom, n, yielding=True
-        )
-        chi_yield = strain[1]
-        if chi_ultimate * chi_yield < 0:
-            # They cannot have opposite signs!
-            raise ValueError(
-                'curvature at yield and ultimate cannot have opposite signs!'
+
+        if chi is None:
+            # Find ultimate curvature from the strain distribution
+            # corresponding to failure and equilibrium with external axial
+            # force
+            strain = self.find_equilibrium_fixed_pivot(rotated_geom, n)
+            chi_ultimate = strain[1]
+            # Find the yielding curvature
+            strain = self.find_equilibrium_fixed_pivot(
+                rotated_geom, n, yielding=True
             )
-
-        # Make sure the sign of the first curvature matches the sign of the
-        # yield curvature
-        chi_first *= -1.0 if chi_first * chi_yield < 0 else 1.0
-
-        # The first curvature should be less than the yield curvature
-        if abs(chi_first) >= abs(chi_yield):
-            chi_first = chi_yield / num_pre_yield
-
-        # Define the array of curvatures
-        if abs(chi_ultimate) <= abs(chi_yield) + 1e-8:
-            # We don't want a plastic branch in the analysis
-            # this is done to speed up analysis
-            chi = np.linspace(chi_first, chi_yield, num_pre_yield)
-        else:
-            chi = np.concatenate(
-                (
-                    np.linspace(
-                        chi_first, chi_yield, num_pre_yield, endpoint=False
-                    ),
-                    np.linspace(chi_yield, chi_ultimate, num_post_yield + 1),
+            chi_yield = strain[1]
+            if chi_ultimate * chi_yield < 0:
+                # They cannot have opposite signs!
+                raise ValueError(
+                    'curvature at yield and ultimate cannot have opposite '
+                    'signs!'
                 )
-            )
+
+            # Make sure the sign of the first curvature matches the sign of the
+            # yield curvature
+            chi_first *= -1.0 if chi_first * chi_yield < 0 else 1.0
+
+            # The first curvature should be less than the yield curvature
+            if abs(chi_first) >= abs(chi_yield):
+                chi_first = chi_yield / num_pre_yield
+
+            # Define the array of curvatures
+            if abs(chi_ultimate) <= abs(chi_yield) + 1e-8:
+                # We don't want a plastic branch in the analysis
+                # this is done to speed up analysis
+                chi = np.linspace(chi_first, chi_yield, num_pre_yield)
+            else:
+                chi = np.concatenate(
+                    (
+                        np.linspace(
+                            chi_first,
+                            chi_yield,
+                            num_pre_yield - 1,
+                            endpoint=False,
+                        ),
+                        np.linspace(
+                            chi_yield, chi_ultimate, num_post_yield + 1
+                        ),
+                    )
+                )
 
         # prepare results
         eps_a = np.zeros_like(chi)


### PR DESCRIPTION
A slight refinement of the `.calculate_moment_curvature` method on the `GenericSectionCalculator`.

- [x] Let the user specify the number of curvatures to calculate the response for.
- [x] Let the user specify the first curvature.
- [x] Let the user provide an array of curvatures.
- [x] Add tests.