### PR TITLE
fix: Update GenericSection to accept SurfaceGeometry

### DIFF
--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -53,6 +53,12 @@ class GenericSection(Section):
         if name is None:
             name = 'GenericSection'
         super().__init__(name)
+        # Since only CompoundGeometry has the attribute geometries,
+        # if a SurfaceGeometry is input, we create a CompoundGeometry
+        # with only that geometry contained. After that all algorithms
+        # work as usal.
+        if isinstance(geometry, SurfaceGeometry):
+            geometry = CompoundGeometry([geometry])
         self.geometry = geometry
         self.section_calculator = GenericSectionCalculator(
             sec=self, integrator=integrator, **kwargs


### PR DESCRIPTION
Update GenericSection to work also with SurfaceGeometry as input.

This fix an issue mentioned in #113 

```
# Materials
concrete = ConcreteEC2_2004(25)
# Create section
poly = Polygon(((0, 0), (350, 0), (350, 500), (0, 500)))
geo = SurfaceGeometry(poly, concrete)
# Section from SurfaceGeometry
sec = GenericSection(geo)
print(f"Area = {sec.gross_properties.area*1e-2} cm2")

# Section from CompoundGeometry
sec = GenericSection(CompoundGeometry([geo]))
print(f"Area = {sec.gross_properties.area*1e-2} cm2") 
```

now both definition works and the output is:
```
Area = 1750.0 cm2
Area = 1750.0 cm2
```