### PR TITLE
fix gross properties sign

### DIFF
--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -179,6 +179,8 @@ class GenericSectionCalculator(SectionCalculator):
                 [0, 1, 0],
                 mesh_size=self.mesh_size,
             )
+            # Change sign due to moment sign convention
+            iyz *= -1
             # Integrate a dummy strain profile for getting first
             # and second moment respect z axis and product moment
             (
@@ -192,13 +194,15 @@ class GenericSectionCalculator(SectionCalculator):
                 tri=tri,
                 mesh_size=self.mesh_size,
             )
+            # Change sign due to moment sign convention
+            izz *= -1
             if abs(abs(izy) - abs(iyz)) > 10:
                 error_str = 'Something went wrong with computation of '
                 error_str += f'moments of area: iyz = {iyz}, izy = {izy}.\n'
                 error_str += 'They should be equal but are not!'
                 raise RuntimeError(error_str)
 
-            return abs(sy), abs(sz), abs(iyy), abs(izz), abs(iyz)
+            return sy, sz, iyy, izz, iyz
 
         # Create a dummy material for integration of area moments
         # This is used for J, S etc, not for E_J E_S etc

--- a/structuralcodes/sections/section_integrators/_marin_integrator.py
+++ b/structuralcodes/sections/section_integrators/_marin_integrator.py
@@ -44,7 +44,7 @@ class MarinIntegrator(SectionIntegrator):
         # and stress coefficients for each part.
         prepared_input = []
         # 1. Rotate section in order to have neutral axis horizontal
-        angle = atan2(strain[2], strain[1])
+        angle = -atan2(strain[2], strain[1])
 
         rotated_geom = geo.rotate(angle)
         # 2. Get y coordinate of neutral axis in this new CRS


### PR DESCRIPTION
Fixed issue mentioned in #113: the gross properties were not working with section defined with negative coordinates.

This code now works as expected (tested both with default Marin and Fiber integrator)

```
# Imports
from shapely import Polygon
from structuralcodes.materials.concrete import ConcreteEC2_2004
from structuralcodes.geometry import SurfaceGeometry,CompoundGeometry
from structuralcodes.sections import GenericSection

# Materials
concrete = ConcreteEC2_2004(25)
# Create Geometry and Section
poly = Polygon(((0, 0), (350, 0), (350, 500), (0, 500)))
geo = SurfaceGeometry(poly, concrete)
# Passing Compound as following is no longer necessary with PR#130
sec = GenericSection(CompoundGeometry([geo]))
# sec = GenericSection(CompoundGeometry([geo]),integrator='fiber',mesh_size=0.001)

poly_neg = Polygon(((0, 0), (-350, 0), (-350, -500), (0, -500)))  # -500 instead of 500
geo_neg = SurfaceGeometry(poly_neg, concrete)
# Passing Compound as following is no longer necessary with PR#130
sec_neg = GenericSection(CompoundGeometry([geo_neg]))
# sec_neg = GenericSection(geo_neg,integrator='fiber',mesh_size=0.001)

print(f'I11 = {round(sec.gross_properties.i11*1e-4)} cm4') 
print(f'I11_neg = {round(sec_neg.gross_properties.i11*1e-4)} cm4')
print(f'Sy = {round(sec.gross_properties.sy*1e-3)} cm3') 
print(f'Sy_neg = {round(sec_neg.gross_properties.sy*1e-3)} cm3')

print(f'I22 = {round(sec.gross_properties.i22*1e-4)} cm4') 
print(f'I22_neg = {round(sec_neg.gross_properties.i22*1e-4)} cm4')
print(f'Sz = {round(sec.gross_properties.sz*1e-3)} cm3') 
print(f'Sz_neg = {round(sec_neg.gross_properties.sz*1e-3)} cm3')
```

The output is:
```
I11 = 364583 cm4
I11_neg = 364583 cm4
Sy = 43750 cm3
Sy_neg = -43750 cm3
I22 = 178646 cm4
I22_neg = 178646 cm4
Sz = 30625 cm3
Sz_neg = -30625 cm3
```