### PR TITLE
Fix area computation on Generic Section

### DIFF
--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -142,6 +142,9 @@ class GenericSectionCalculator(SectionCalculator):
                 # this assumes area in mm2 and density in kg/m3
                 gp.mass += geo.area * geo.density * 1e-9
 
+        # Add area of reinforcement to total area
+        gp.area += gp.area_reinforcement
+
         # Computation of area moments
         #
         # Implementation idea:

--- a/tests/test_core/test_generic_section.py
+++ b/tests/test_core/test_generic_section.py
@@ -27,8 +27,16 @@ def test_rectangular_section():
     # The section
     poly = Polygon(((0, 0), (200, 0), (200, 400), (0, 400)))
     geo = SurfaceGeometry(poly, concrete)
-    geo = add_reinforcement_line(geo, (40, 40), (160, 40), 16, steel, n=4)
-    geo = add_reinforcement_line(geo, (40, 360), (160, 360), 16, steel, n=4)
+    diam_reinf = 16
+    area_reinf = diam_reinf**2 * math.pi / 4.0
+    n_reinf = 4
+    expected_area = 200 * 400 + 2 * area_reinf * n_reinf
+    geo = add_reinforcement_line(
+        geo, (40, 40), (160, 40), diam_reinf, steel, n=n_reinf
+    )
+    geo = add_reinforcement_line(
+        geo, (40, 360), (160, 360), diam_reinf, steel, n=n_reinf
+    )
     geo = geo.translate(-100, -200)
     assert geo.geometries[0].centroid[0] == 0
     assert geo.geometries[0].centroid[1] == 0
@@ -37,7 +45,7 @@ def test_rectangular_section():
     sec = GenericSection(geo)
     assert sec.name == 'GenericSection'
 
-    assert math.isclose(sec.gross_properties.area, 200 * 400)
+    assert math.isclose(sec.gross_properties.area, expected_area)
 
     # Compute bending strength
     res_marin = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
@@ -52,7 +60,7 @@ def test_rectangular_section():
 
     # Use fiber integration
     sec = GenericSection(geo, integrator='Fiber', mesh_size=0.0001)
-    assert math.isclose(sec.gross_properties.area, 200 * 400)
+    assert math.isclose(sec.gross_properties.area, expected_area)
 
     # Compute bending strength
     res_fiber = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
@@ -243,10 +251,18 @@ def test_rectangular_section_Sargin():
     )
 
     # The section
+    diam_reinf = 16
+    area_reinf = diam_reinf**2 * math.pi / 4.0
+    n_reinf = 4
+    expected_area = 200 * 400 + 2 * area_reinf * n_reinf
     poly = Polygon(((0, 0), (200, 0), (200, 400), (0, 400)))
     geo = SurfaceGeometry(poly, concrete)
-    geo = add_reinforcement_line(geo, (40, 40), (160, 40), 16, steel, n=4)
-    geo = add_reinforcement_line(geo, (40, 360), (160, 360), 16, steel, n=4)
+    geo = add_reinforcement_line(
+        geo, (40, 40), (160, 40), diam_reinf, steel, n=n_reinf
+    )
+    geo = add_reinforcement_line(
+        geo, (40, 360), (160, 360), diam_reinf, steel, n=n_reinf
+    )
     geo = geo.translate(-100, -200)
     assert geo.geometries[0].centroid[0] == 0
     assert geo.geometries[0].centroid[1] == 0
@@ -254,14 +270,22 @@ def test_rectangular_section_Sargin():
     # Create the section (default Marin integrator)
     sec = GenericSection(geo)
 
-    assert math.isclose(sec.gross_properties.area, 200 * 400)
+    assert math.isclose(sec.gross_properties.area, expected_area)
+    assert math.isclose(sec.gross_properties.area_surface, 200 * 400)
+    assert math.isclose(
+        sec.gross_properties.area_reinforcement, area_reinf * n_reinf * 2
+    )
 
     # Compute bending strength
     res_marin = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
 
     # Use fiber integration
     sec = GenericSection(geo, integrator='Fiber', mesh_size=0.0001)
-    assert math.isclose(sec.gross_properties.area, 200 * 400)
+    assert math.isclose(sec.gross_properties.area, expected_area)
+    assert math.isclose(sec.gross_properties.area_surface, 200 * 400)
+    assert math.isclose(
+        sec.gross_properties.area_reinforcement, area_reinf * n_reinf * 2
+    )
 
     # Compute bending strength
     res_fiber = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
@@ -284,8 +308,16 @@ def test_holed_section():
     geo = SurfaceGeometry(poly, concrete)
 
     # Add reinforcement
-    geo = add_reinforcement_line(geo, (50, 50), (450, 50), 28, steel, n=4)
-    geo = add_reinforcement_line(geo, (50, 950), (450, 950), 28, steel, n=4)
+    diam_reinf = 28
+    area_reinf = diam_reinf**2 * math.pi / 4.0
+    n_reinf = 4
+    expected_area = 260000 + 2 * area_reinf * n_reinf
+    geo = add_reinforcement_line(
+        geo, (50, 50), (450, 50), diam_reinf, steel, n=n_reinf
+    )
+    geo = add_reinforcement_line(
+        geo, (50, 950), (450, 950), diam_reinf, steel, n=n_reinf
+    )
     # Translate the section
     geo = geo.translate(-250, -500)
     assert geo.geometries[0].centroid[0] == 0
@@ -295,14 +327,16 @@ def test_holed_section():
     sec = GenericSection(geo)
     assert sec.name == 'GenericSection'
 
-    assert math.isclose(sec.gross_properties.area, 260000)
+    assert math.isclose(sec.gross_properties.area, expected_area)
+    assert math.isclose(sec.gross_properties.area_surface, 260000)
 
     # Compute bending strength with Marin
     res_marin = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
 
     # Use fiber integration
     sec = GenericSection(geo, integrator='Fiber', mesh_size=0.0001)
-    assert math.isclose(sec.gross_properties.area, 260000)
+    assert math.isclose(sec.gross_properties.area, expected_area)
+    assert math.isclose(sec.gross_properties.area_surface, 260000)
 
     # Compute bending strength
     res_fiber = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
@@ -329,9 +363,15 @@ def test_u_section():
     geo = SurfaceGeometry(poly, concrete)
 
     # Add reinforcement
-    geo = add_reinforcement_line(geo, (50, 50), (450, 50), 28, steel, n=4)
-    geo = add_reinforcement(geo, (50, 950), 28, steel)
-    geo = add_reinforcement(geo, (450, 950), 28, steel)
+    diam_reinf = 28
+    area_reinf = diam_reinf**2 * math.pi / 4.0
+    n_reinf = 4
+    expected_area = 230000 + area_reinf * (n_reinf + 2)
+    geo = add_reinforcement_line(
+        geo, (50, 50), (450, 50), diam_reinf, steel, n=n_reinf
+    )
+    geo = add_reinforcement(geo, (50, 950), diam_reinf, steel)
+    geo = add_reinforcement(geo, (450, 950), diam_reinf, steel)
     # Translate the section
     geo = geo.translate(-250, -441.30434782608694)
     assert geo.geometries[0].centroid[0] == 0
@@ -341,14 +381,16 @@ def test_u_section():
     sec = GenericSection(geo)
     assert sec.name == 'GenericSection'
 
-    assert math.isclose(sec.gross_properties.area, 230000)
+    assert math.isclose(sec.gross_properties.area, expected_area)
+    assert math.isclose(sec.gross_properties.area_surface, 230000)
 
     # Compute bending strength
     res_marin = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
 
     # Use fiber integration
     sec = GenericSection(geo, integrator='Fiber', mesh_size=0.0001)
-    assert math.isclose(sec.gross_properties.area, 230000)
+    assert math.isclose(sec.gross_properties.area, expected_area)
+    assert math.isclose(sec.gross_properties.area_surface, 230000)
 
     # Compute bending strength
     res_fiber = sec.section_calculator.calculate_bending_strength(theta=0, n=0)


### PR DESCRIPTION
This fix an issue mentioned in PR #113: the area should be the sum of surface + reinforcement area.

This code now returns the expected value:

```
# imports
from shapely import Polygon
from structuralcodes.materials.concrete import ConcreteEC2_2004
from structuralcodes.materials.reinforcement import ReinforcementEC2_2004
from structuralcodes.geometry import SurfaceGeometry
from structuralcodes.sections._reinforcement import add_reinforcement_line
from structuralcodes.sections import GenericSection

# Materials
concrete = ConcreteEC2_2004(25)
reinforcemnet = ReinforcementEC2_2004(fyk=500, Es=200000, density=7850, ftk=550, epsuk=0.07) 

# Create section
poly = Polygon(((0, 0), (350, 0), (350, 500), (0, 500)))
geo = SurfaceGeometry(poly, concrete)
geo = add_reinforcement_line(geo, (50, 450), (300, 450), 12, reinforcemnet, n=3)
geo = add_reinforcement_line(geo, (50, 50), (300, 50), 20, reinforcemnet, n=6)
sec = GenericSection(geo, integrator='marin')
# Print gross properties
print(f"area = {round(sec.gross_properties.area*1e-2)} cm2")
print(f"area_reinforcement = {round(sec.gross_properties.area_reinforcement*1e-2)} cm2")
print(f"area_surface = {round(sec.gross_properties.area_surface*1e-2)} cm2")
```

and the output is:
```
area = 1772 cm2
area_reinforcement = 22 cm2
area_surface = 1750 cm2
```
