### PR TITLE
fix: bugfix marin coefficients

### DIFF
--- a/structuralcodes/materials/concrete/_concrete.py
+++ b/structuralcodes/materials/concrete/_concrete.py
@@ -4,10 +4,7 @@ import abc
 import typing as t
 
 from structuralcodes.core.base import ConstitutiveLaw, Material
-from structuralcodes.materials.constitutive_laws import (
-    ParabolaRectangle,
-    create_constitutive_law,
-)
+from structuralcodes.materials.constitutive_laws import create_constitutive_law
 
 
 class Concrete(Material):
@@ -60,9 +57,7 @@ class Concrete(Material):
     def constitutive_law(self) -> ConstitutiveLaw:
         """Returns the constitutive law object."""
         if self._constitutive_law is None:
-            self._constitutive_law = ParabolaRectangle(
-                self.fcd(), name=self.name + '_ConstLaw'
-            )
+            self.constitutive_law = 'parabolarectangle'
         return self._constitutive_law
 
     @constitutive_law.setter

--- a/structuralcodes/materials/constitutive_laws.py
+++ b/structuralcodes/materials/constitutive_laws.py
@@ -309,7 +309,7 @@ class ParabolaRectangle(ConstitutiveLaw):
         if self._n != 2:
             # The constitutive law is not writtable as a polynomial,
             # Call the generic distretizing method
-            return super().__marin__
+            return super().__marin__(strain=strain)
 
         strains = []
         coeff = []

--- a/structuralcodes/materials/constitutive_laws.py
+++ b/structuralcodes/materials/constitutive_laws.py
@@ -267,8 +267,13 @@ class ParabolaRectangle(ConstitutiveLaw):
         # Preprocess eps array in order
         eps = self.preprocess_strains_with_limits(eps=eps)
         # Compute stress
+        sig = np.zeros_like(eps)
         # Parabolic branch
-        sig = self._fc * (1 - (1 - (eps / self._eps_0)) ** self._n)
+        sig[(eps <= 0) & (eps >= self._eps_0)] = self._fc * (
+            1
+            - (1 - (eps[(eps <= 0) & (eps >= self._eps_0)] / self._eps_0))
+            ** self._n
+        )
         # Rectangle branch
         sig[eps < self._eps_0] = self._fc
         # Zero elsewhere
@@ -280,11 +285,13 @@ class ParabolaRectangle(ConstitutiveLaw):
         """Return the tangent given strain."""
         eps = np.atleast_1d(np.asarray(eps))
         # parabolic branch
-        tangent = (
+        tangent = np.zeros_like(eps)
+        tangent[(eps <= 0) & (eps >= self._eps_0)] = (
             self._n
             * self._fc
             / self._eps_0
-            * (1 - (eps / self._eps_0)) ** (self._n - 1)
+            * (1 - (eps[(eps <= 0) & (eps >= self._eps_0)] / self._eps_0))
+            ** (self._n - 1)
         )
         # Elsewhere tangent is zero
         tangent[eps < self._eps_0] = 0.0

--- a/structuralcodes/materials/constitutive_laws.py
+++ b/structuralcodes/materials/constitutive_laws.py
@@ -306,6 +306,11 @@ class ParabolaRectangle(ConstitutiveLaw):
             [(0, -0.002), (-0.002, -0.003)]
             [(a0, a1, a2), (a0)]
         """
+        if self._n != 2:
+            # The constitutive law is not writtable as a polynomial,
+            # Call the generic distretizing method
+            return super().__marin__
+
         strains = []
         coeff = []
         if strain[1] == 0:


### PR DESCRIPTION
Fixed a bug in parabola-rectangle constitutive law function for evaluation of Marin coefficients. The computation of the coefficients assumed the exponent of the parabolic part is equal to 2. If the exponent is different than 2, the marin method for all constitutive laws (even if less efficient) is called.