### PR TITLE
fix: improve API for interaction domain

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,4 +20,4 @@ lint:  ## Linting and static type checking
 	python -m ruff check tests
 
 test:  ## Run tests and output reports
-	python -m pytest --junitxml=junit/test-results.xml --cov=$(PACKAGE_NAME) --cov-report=term-missing --cov-report=html
+	python -m pytest --junitxml=junit/test-results.xml --cov=$(PACKAGE_NAME) --cov-report=term-missing --cov-report=xml

--- a/makefile
+++ b/makefile
@@ -20,4 +20,4 @@ lint:  ## Linting and static type checking
 	python -m ruff check tests
 
 test:  ## Run tests and output reports
-	python -m pytest --junitxml=junit/test-results.xml --cov=$(PACKAGE_NAME) --cov-report=term-missing --cov-report=xml
+	python -m pytest --junitxml=junit/test-results.xml --cov=$(PACKAGE_NAME) --cov-report=term-missing --cov-report=html

--- a/structuralcodes/core/_section_results.py
+++ b/structuralcodes/core/_section_results.py
@@ -196,6 +196,8 @@ class NMInteractionDomain:
     m_y: ArrayLike = None  # Moments My
     m_z: ArrayLike = None  # Moments Mz
 
+    strains: ArrayLike = None
+
 
 @dataclass
 class MMInteractionDomain:

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -777,41 +777,41 @@ class GenericSectionCalculator(SectionCalculator):
 
     def _process_num_strain_profiles(
         self,
-        num: int,
-        min_1: int = 2,
+        num: int = 35,
+        min_1: int = 1,
         min_2: int = 2,
         min_3: int = 15,
         min_4: int = 10,
         min_5: int = 3,
         min_6: int = 4,
     ):
-        """Return number of strain profiles for each field given the total numb
-        er of strain profiles.
+        """Return number of strain profiles for each field given the total
+        number of strain profiles.
 
         If the total number of strain profiles is given by user, divide this
         for every field according to a default pre-defined discretization
-        for each field (1, 2, 15, 10, 3, 4 for fields 1 to 6).
-        For each field if the user set a desired minimum number of strain
-        profiles, guarantee to create a number of strain profiles greater or
-        equal to the desired one. Therefore the function never return less
-        strain profiles than desired.
+        for each field (1, 2, 15, 10, 3, 4 for fields 1 to 6). For each field
+        if the user set a desired minimum number of strain profiles, guarantee
+        to create a number of strain profiles greater or equal to the desired
+        one. Therefore the function never return less strain profiles than
+        desired.
 
         Arguments:
-        num (int): Total number of strain profiles (Optional, default = None).
-            If specified num and num_1, ..., num_6 the total number of num
-            may be different.
-        min_1 (int): Minimum number of strain profiles in field 1
-            (Optional, default = 1).
-        min_2 (int): Minimum number of strain profiles in field 2
-            (Optional, default = 2).
-        min_3 (int): Minimum number of strain profiles in field 3
-            (Optional, default = 15).
-        min_4 (int): Minimum number of strain profiles in field 4
-            (Optional, default = 10).
-        min_5 (int): Minimum number of strain profiles in field 5
-            (Optional, default = 3).
-        min_6 (int): Minimum number of strain profiles in field 6
-            (Optional, default = 4).
+            num (int): Total number of strain profiles (Optional, default =
+                35). If specified num and num_1, ..., num_6 the total number of
+                num may be different.
+            min_1 (int): Minimum number of strain profiles in field 1
+                (Optional, default = 1).
+            min_2 (int): Minimum number of strain profiles in field 2
+                (Optional, default = 2).
+            min_3 (int): Minimum number of strain profiles in field 3
+                (Optional, default = 15).
+            min_4 (int): Minimum number of strain profiles in field 4
+                (Optional, default = 10).
+            min_5 (int): Minimum number of strain profiles in field 5
+                (Optional, default = 3).
+            min_6 (int): Minimum number of strain profiles in field 6
+                (Optional, default = 4).
 
         Return:
             (int, int, int, int, int, int): 6-tuple of int number representing
@@ -851,44 +851,39 @@ class GenericSectionCalculator(SectionCalculator):
         """Calculate the NM interaction domain.
 
         Arguments:
-        theta (float): Inclination of n.a. respect to y axis
-            (Optional, default = 0).
-        num_1 (int): Number of strain profiles in field 1
-            (Optional, default = 1).
-        num_2 (int): Number of strain profiles in field 2
-            (Optional, default = 2).
-        num_3 (int): Number of strain profiles in field 3
-            (Optional, default = 15).
-        num_4 (int): Number of strain profiles in field 4
-            (Optional, default = 10).
-        num_5 (int): Number of strain profiles in field 5
-            (Optional, default = 3).
-        num_6 (int): Number of strain profiles in field 6
-            (Optional, default = 4).
-        num (int): Total number of strain profiles (Optional, default = None).
-            If specified num and num_1, ..., num_6 the total number of num
-            may be different.
-        type_1 (literal): Type of spacing for field 1.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_2 (literal): Type of spacing for field 2.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_3 (literal): Type of spacing for field 3.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_4 (literal): Type of spacing for field 4.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_5 (literal): Type of spacing for field 5.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_6 (literal): Type of spacing for field 6.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
+            theta (float): Inclination of n.a. respect to y axis
+                (Optional, default = 0).
+            num_1 (int): Number of strain profiles in field 1
+                (Optional, default = 1).
+            num_2 (int): Number of strain profiles in field 2
+                (Optional, default = 2).
+            num_3 (int): Number of strain profiles in field 3
+                (Optional, default = 15).
+            num_4 (int): Number of strain profiles in field 4
+                (Optional, default = 10).
+            num_5 (int): Number of strain profiles in field 5
+                (Optional, default = 3).
+            num_6 (int): Number of strain profiles in field 6
+                (Optional, default = 4).
+            num (int): Total number of strain profiles (Optional, default =
+                None). If specified num and num_1, ..., num_6 the total number
+                of num may be different.
+            type_1 (str): Type of spacing for field 1. 'linear' for a
+                linear spacing, 'geometric' for a geometric spacing 'quadratic'
+                for a quadratic spacing (default = 'linear').
+            type_2 (str): Type of spacing for field 2 (default = 'linear'). See
+                type_1 for options.
+            type_3 (str): Type of spacing for field 3 (default = 'geometric').
+                See type_1 for options.
+            type_4 (str): Type of spacing for field 4 (default = 'linear'). See
+                type_1 for options.
+            type_5 (str): Type of spacing for field 5 (default = 'linear'). See
+                type_1 for options.
+            type_6 (str): Type of spacing for field 6 (default = 'linear'). See
+                type_1 for options.
 
-        Return:
-        (NmInteractionDomain)
+        Returns:
+            (NmInteractionDomain)
         """
         # Prepare the results
         res = s_res.NMInteractionDomain()
@@ -962,38 +957,33 @@ class GenericSectionCalculator(SectionCalculator):
     ):
         """Return an array of ultimate strain profiles.
 
-        Args:
-        theta (float): The angle of neutral axis.
-        num_1 (int): Number of strain profiles in field 1
-            (Optional, default = 1).
-        num_2 (int): Number of strain profiles in field 2
-            (Optional, default = 2).
-        num_3 (int): Number of strain profiles in field 3
-            (Optional, default = 15).
-        num_4 (int): Number of strain profiles in field 4
-            (Optional, default = 10).
-        num_5 (int): Number of strain profiles in field 5
-            (Optional, default = 3).
-        num_6 (int): Number of strain profiles in field 6
-            (Optional, default = 4).
-        type_1 (literal): Type of spacing for field 1.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_2 (literal): Type of spacing for field 2.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_3 (literal): Type of spacing for field 3.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_4 (literal): Type of spacing for field 4.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_5 (literal): Type of spacing for field 5.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_6 (literal): Type of spacing for field 6.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        Arguments:
+            theta (float): The angle of neutral axis.
+            num_1 (int): Number of strain profiles in field 1
+                (Optional, default = 1).
+            num_2 (int): Number of strain profiles in field 2
+                (Optional, default = 2).
+            num_3 (int): Number of strain profiles in field 3
+                (Optional, default = 15).
+            num_4 (int): Number of strain profiles in field 4
+                (Optional, default = 10).
+            num_5 (int): Number of strain profiles in field 5
+                (Optional, default = 3).
+            num_6 (int): Number of strain profiles in field 6
+                (Optional, default = 4).
+            type_1 (literal): Type of spacing for field 1. 'linear' for a
+                linear spacing, 'geometric' for a geometric spacing 'quadratic'
+                for a quadratic spacing (Optional default = 'linear').
+            type_2 (literal): Type of spacing for field 2 (default = 'linear').
+                See type_1 for options.
+            type_3 (literal): Type of spacing for field 3 (default =
+                'geometric'). See type_1 for options.
+            type_4 (literal): Type of spacing for field 4 (default = 'linear').
+                See type_1 for options.
+            type_5 (literal): Type of spacing for field 5 (default = 'linear').
+                See type_1 for options.
+            type_6 (literal): Type of spacing for field 6 (default = 'linear').
+                See type_1 for options.
         """
         rotated_geom = self.section.geometry.rotate(-theta)
 
@@ -1123,45 +1113,40 @@ class GenericSectionCalculator(SectionCalculator):
     ) -> s_res.NMMInteractionDomain:
         """Calculates the NMM interaction domain.
 
-        Args:
-        num_theta (int): Number of discretization of angle of neutral axis
-            (Optional, Default = 32).
-        num_1 (int): Number of strain profiles in field 1
-            (Optional, default = 1).
-        num_2 (int): Number of strain profiles in field 2
-            (Optional, default = 2).
-        num_3 (int): Number of strain profiles in field 3
-            (Optional, default = 15).
-        num_4 (int): Number of strain profiles in field 4
-            (Optional, default = 10).
-        num_5 (int): Number of strain profiles in field 5
-            (Optional, default = 3).
-        num_6 (int): Number of strain profiles in field 6
-            (Optional, default = 4).
-        num (int): Total number of strain profiles (Optional, default = None).
-            If specified num and num_1, ..., num_6 the total number of num
-            may be different.
-        type_1 (literal): Type of spacing for field 1.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_2 (literal): Type of spacing for field 2.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_3 (literal): Type of spacing for field 3.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_4 (literal): Type of spacing for field 4.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_5 (literal): Type of spacing for field 5.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
-        type_6 (literal): Type of spacing for field 6.
-            'linear' for a linear spacing, 'geometric' for a geometric spacing
-            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        Arguments:
+            num_theta (int): Number of discretization of angle of neutral axis
+                (Optional, Default = 32).
+            num_1 (int): Number of strain profiles in field 1
+                (Optional, default = 1).
+            num_2 (int): Number of strain profiles in field 2
+                (Optional, default = 2).
+            num_3 (int): Number of strain profiles in field 3
+                (Optional, default = 15).
+            num_4 (int): Number of strain profiles in field 4
+                (Optional, default = 10).
+            num_5 (int): Number of strain profiles in field 5
+                (Optional, default = 3).
+            num_6 (int): Number of strain profiles in field 6
+                (Optional, default = 4).
+            num (int): Total number of strain profiles (Optional, default =
+                None). If specified num and num_1, ..., num_6 the total number
+                of num may be different.
+            type_1 (literal): Type of spacing for field 1. 'linear' for a
+                linear spacing, 'geometric' for a geometric spacing 'quadratic'
+                for a quadratic spacing (Optional default = 'linear').
+            type_2 (literal): Type of spacing for field 2 (default = 'linear').
+                See type_1 for options.
+            type_3 (literal): Type of spacing for field 3 (default =
+                'geometric'). See type_1 for options.
+            type_4 (literal): Type of spacing for field 4 (default = 'linear').
+                See type_1 for options.
+            type_5 (literal): Type of spacing for field 5 (default = 'linear').
+                See type_1 for options.
+            type_6 (literal): Type of spacing for field 6 (default = 'linear').
+                See type_1 for options.
 
         Return:
-        (NMMInteractionDomain)
+            (NMMInteractionDomain)
         """
         res = s_res.NMMInteractionDomain()
         res.num_theta = num_theta

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -586,6 +586,7 @@ class GenericSectionCalculator(SectionCalculator):
             geo=self.section.geometry,
             strain=strain,
             tri=self.triangulated_data,
+            mesh_size=self.mesh_size,
         )
         return N, My, Mz
 
@@ -774,54 +775,117 @@ class GenericSectionCalculator(SectionCalculator):
 
         return res
 
+    def _process_num_strain_profiles(
+        self,
+        num: int,
+        min_1: int = 2,
+        min_2: int = 2,
+        min_3: int = 15,
+        min_4: int = 10,
+        min_5: int = 3,
+        min_6: int = 4,
+    ):
+        """Return number of strain profiles for each field given the total numb
+        er of strain profiles.
+
+        If the total number of strain profiles is given by user, divide this
+        for every field according to a default pre-defined discretization
+        for each field (1, 2, 15, 10, 3, 4 for fields 1 to 6).
+        For each field if the user set a desired minimum number of strain
+        profiles, guarantee to create a number of strain profiles greater or
+        equal to the desired one. Therefore the function never return less
+        strain profiles than desired.
+
+        Arguments:
+        num (int): Total number of strain profiles (Optional, default = None).
+            If specified num and num_1, ..., num_6 the total number of num
+            may be different.
+        min_1 (int): Minimum number of strain profiles in field 1
+            (Optional, default = 1).
+        min_2 (int): Minimum number of strain profiles in field 2
+            (Optional, default = 2).
+        min_3 (int): Minimum number of strain profiles in field 3
+            (Optional, default = 15).
+        min_4 (int): Minimum number of strain profiles in field 4
+            (Optional, default = 10).
+        min_5 (int): Minimum number of strain profiles in field 5
+            (Optional, default = 3).
+        min_6 (int): Minimum number of strain profiles in field 6
+            (Optional, default = 4).
+
+        Return:
+            (int, int, int, int, int, int): 6-tuple of int number representing
+            number of strain profiles for each field.
+        """
+        n1_attempt = int(num / 35 * 1)
+        n2_attempt = int(num / 35 * 2)
+        n3_attempt = int(num / 35 * 15)
+        n4_attempt = int(num / 35 * 10)
+        n5_attempt = int(num / 35 * 3)
+        n6_attempt = int(num / 35 * 4)
+        num_1 = max(n1_attempt, min_1)
+        num_2 = max(n2_attempt, min_2)
+        num_3 = max(n3_attempt, min_3)
+        num_4 = max(n4_attempt, min_4)
+        num_5 = max(n5_attempt, min_5)
+        num_6 = max(n6_attempt, min_6)
+        return (num_1, num_2, num_3, num_4, num_5, num_6)
+
     def calculate_nm_interaction_domain(
         self,
         theta: float = 0,
-        n1: int = 1,
-        n2: int = 2,
-        n3: int = 15,
-        n4: int = 10,
-        n5: int = 3,
-        n6: int = 4,
-        n: t.Optional[int] = None,
-        type1: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type2: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type3: t.Literal['linear', 'geometric', 'quadratic'] = 'geometric',
-        type4: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type5: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type6: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        num_1: int = 1,
+        num_2: int = 2,
+        num_3: int = 15,
+        num_4: int = 10,
+        num_5: int = 3,
+        num_6: int = 4,
+        num: t.Optional[int] = None,
+        type_1: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_2: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_3: t.Literal['linear', 'geometric', 'quadratic'] = 'geometric',
+        type_4: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_5: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_6: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
     ) -> s_res.NMInteractionDomain:
         """Calculate the NM interaction domain.
 
         Arguments:
-        theta (float): inclination of n.a. respect to y axis
-            (Optional, default = 0)
-        n1: (int) number of strain profiles in field 1 (Optional, default = 1)
-        n2: (int) number of strain profiles in field 2 (Optional, default = 2)
-        n3: (int) number of strain profiles in field 3 (Optional, default = 15)
-        n4: (int) number of strain profiles in field 4 (Optional, default = 10)
-        n5: (int) number of strain profiles in field 5 (Optional, default = 3)
-        n6: (int) number of strain profiles in field 6 (Optional, default = 4)
-        n: (int) total number of strain profiles (Optional, default = None)
-            If specified n and n1..n6 the total number of n may be different.
-        type1: (literal) type of spacing for field 1
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type2: (literal) type of spacing for field 2
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type3: (literal) type of spacing for field 3
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'geometric')
-        type4: (literal) type of spacing for field 4
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type5: (literal) type of spacing for field 5
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type6: (literal) type of spacing for field 6
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
+        theta (float): Inclination of n.a. respect to y axis
+            (Optional, default = 0).
+        num_1 (int): Number of strain profiles in field 1
+            (Optional, default = 1).
+        num_2 (int): Number of strain profiles in field 2
+            (Optional, default = 2).
+        num_3 (int): Number of strain profiles in field 3
+            (Optional, default = 15).
+        num_4 (int): Number of strain profiles in field 4
+            (Optional, default = 10).
+        num_5 (int): Number of strain profiles in field 5
+            (Optional, default = 3).
+        num_6 (int): Number of strain profiles in field 6
+            (Optional, default = 4).
+        num (int): Total number of strain profiles (Optional, default = None).
+            If specified num and num_1, ..., num_6 the total number of num
+            may be different.
+        type_1 (literal): Type of spacing for field 1.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_2 (literal): Type of spacing for field 2.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_3 (literal): Type of spacing for field 3.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_4 (literal): Type of spacing for field 4.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_5 (literal): Type of spacing for field 5.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_6 (literal): Type of spacing for field 6.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
 
         Return:
         (NmInteractionDomain)
@@ -830,36 +894,29 @@ class GenericSectionCalculator(SectionCalculator):
         res = s_res.NMInteractionDomain()
         res.theta = theta
 
-        # Process n
-        if n is not None:
-            n1_attempt = int(n / 35 * 1)
-            n2_attempt = int(n / 35 * 2)
-            n3_attempt = int(n / 35 * 15)
-            n4_attempt = int(n / 35 * 10)
-            n5_attempt = int(n / 35 * 3)
-            n6_attempt = int(n / 35 * 4)
-            n1 = max(n1_attempt, n1)
-            n2 = max(n2_attempt, n2)
-            n3 = max(n3_attempt, n3)
-            n4 = max(n4_attempt, n4)
-            n5 = max(n5_attempt, n5)
-            n6 = max(n6_attempt, n6)
+        # Process num if given.
+        if num is not None:
+            num_1, num_2, num_3, num_4, num_5, num_6 = (
+                self._process_num_strain_profiles(
+                    num, num_1, num_2, num_3, num_4, num_5, num_6
+                )
+            )
 
         # Get ultimate strain profiles for theta angle
         strains = self._compute_ultimate_strain_profiles(
             theta=theta,
-            n1=n1,
-            n2=n2,
-            n3=n3,
-            n4=n4,
-            n5=n5,
-            n6=n6,
-            type1=type1,
-            type2=type2,
-            type3=type3,
-            type4=type4,
-            type5=type5,
-            type6=type6,
+            num_1=num_1,
+            num_2=num_2,
+            num_3=num_3,
+            num_4=num_4,
+            num_5=num_5,
+            num_6=num_6,
+            type_1=type_1,
+            type_2=type_2,
+            type_3=type_3,
+            type_4=type_4,
+            type_5=type_5,
+            type_6=type_6,
         )
 
         # integrate all strain profiles
@@ -890,47 +947,53 @@ class GenericSectionCalculator(SectionCalculator):
     def _compute_ultimate_strain_profiles(
         self,
         theta: float = 0,
-        n1: int = 3,
-        n2: int = 10,
-        n3: int = 40,
-        n4: int = 10,
-        n5: int = 40,
-        n6: int = 40,
-        type1: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type2: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type3: t.Literal['linear', 'geometric', 'quadratic'] = 'geometric',
-        type4: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type5: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type6: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        num_1: int = 1,
+        num_2: int = 2,
+        num_3: int = 15,
+        num_4: int = 10,
+        num_5: int = 3,
+        num_6: int = 4,
+        type_1: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_2: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_3: t.Literal['linear', 'geometric', 'quadratic'] = 'geometric',
+        type_4: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_5: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_6: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
     ):
         """Return an array of ultimate strain profiles.
 
         Args:
-        theta: (float) the angle of neutral axis
-        n1: (int) number of strain profiles in field 1 (Optional, default = 3)
-        n2: (int) number of strain profiles in field 2 (Optional, default = 10)
-        n3: (int) number of strain profiles in field 3 (Optional, default = 40)
-        n4: (int) number of strain profiles in field 4 (Optional, default = 10)
-        n5: (int) number of strain profiles in field 5 (Optional, default = 40)
-        n6: (int) number of strain profiles in field 6 (Optional, default = 40)
-        type1: (literal) type of spacing for field 1
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type2: (literal) type of spacing for field 2
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type3: (literal) type of spacing for field 3
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'geometric')
-        type4: (literal) type of spacing for field 4
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type5: (literal) type of spacing for field 5
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type6: (literal) type of spacing for field 6
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
+        theta (float): The angle of neutral axis.
+        num_1 (int): Number of strain profiles in field 1
+            (Optional, default = 1).
+        num_2 (int): Number of strain profiles in field 2
+            (Optional, default = 2).
+        num_3 (int): Number of strain profiles in field 3
+            (Optional, default = 15).
+        num_4 (int): Number of strain profiles in field 4
+            (Optional, default = 10).
+        num_5 (int): Number of strain profiles in field 5
+            (Optional, default = 3).
+        num_6 (int): Number of strain profiles in field 6
+            (Optional, default = 4).
+        type_1 (literal): Type of spacing for field 1.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_2 (literal): Type of spacing for field 2.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_3 (literal): Type of spacing for field 3.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_4 (literal): Type of spacing for field 4.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_5 (literal): Type of spacing for field 5.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_6 (literal): Type of spacing for field 6.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
         """
         rotated_geom = self.section.geometry.rotate(-theta)
 
@@ -980,29 +1043,29 @@ class GenericSectionCalculator(SectionCalculator):
 
         # For generation of fields 1 and 2 pivot on positive strain
         # Field 1: pivot on positive strain
-        eps_n = _np_space(eps_p_b, 0, n1, type1, endpoint=False)
+        eps_n = _np_space(eps_p_b, 0, num_1, type_1, endpoint=False)
         eps_p = np.zeros_like(eps_n) + eps_p_b
         # Field 2: pivot on positive strain
         eps_n = np.append(
-            eps_n, _np_space(0, eps_n_b, n2, type2, endpoint=False)
+            eps_n, _np_space(0, eps_n_b, num_2, type_2, endpoint=False)
         )
-        eps_p = np.append(eps_p, np.zeros(n2) + eps_p_b)
+        eps_p = np.append(eps_p, np.zeros(num_2) + eps_p_b)
         # For fields 3-4-5 pivot on negative strain
         # Field 3: pivot on negative strain
-        eps_n = np.append(eps_n, np.zeros(n3) + eps_n_b)
+        eps_n = np.append(eps_n, np.zeros(num_3) + eps_n_b)
         eps_p = np.append(
-            eps_p, _np_space(eps_p_b, eps_p_y, n3, type3, endpoint=False)
+            eps_p, _np_space(eps_p_b, eps_p_y, num_3, type_3, endpoint=False)
         )
         # Field 4: pivot on negative strain
-        eps_n = np.append(eps_n, np.zeros(n4) + eps_n_b)
+        eps_n = np.append(eps_n, np.zeros(num_4) + eps_n_b)
         eps_p = np.append(
-            eps_p, _np_space(eps_p_y, 0, n4, type4, endpoint=False)
+            eps_p, _np_space(eps_p_y, 0, num_4, type_4, endpoint=False)
         )
         # Field 5: pivot on negative strain
         eps_p_lim = eps_n_b * (h - (y_n - y_p)) / h
-        eps_n = np.append(eps_n, np.zeros(n5) + eps_n_b)
+        eps_n = np.append(eps_n, np.zeros(num_5) + eps_n_b)
         eps_p = np.append(
-            eps_p, _np_space(0, eps_p_lim, n5, type5, endpoint=False)
+            eps_p, _np_space(0, eps_p_lim, num_5, type_5, endpoint=False)
         )
         # Field 6: pivot on eps_n_y point or eps_n_b
         # If reinforced concrete section pivot on eps_n_y (default -0.002)
@@ -1010,7 +1073,9 @@ class GenericSectionCalculator(SectionCalculator):
         if self.section.geometry.reinforced_concrete:
             z_pivot = y_n - (1 - eps_n_y / eps_n_b) * h
             eps_p_6 = np.append(
-                _np_space(eps_p_lim, eps_n_y, n6 - 1, type6, endpoint=False),
+                _np_space(
+                    eps_p_lim, eps_n_y, num_6 - 1, type_6, endpoint=False
+                ),
                 eps_n_y,
             )
             eps_n_6 = (
@@ -1018,9 +1083,11 @@ class GenericSectionCalculator(SectionCalculator):
                 + eps_n_y
             )
         else:
-            eps_n_6 = np.zeros(n6) + eps_n_b
+            eps_n_6 = np.zeros(num_6) + eps_n_b
             eps_p_6 = np.append(
-                _np_space(eps_p_lim, eps_n_b, n6 - 1, type6, endpoint=False),
+                _np_space(
+                    eps_p_lim, eps_n_b, num_6 - 1, type_6, endpoint=False
+                ),
                 eps_n_b,
             )
         eps_n = np.append(eps_n, eps_n_6)
@@ -1040,51 +1107,58 @@ class GenericSectionCalculator(SectionCalculator):
     def calculate_nmm_interaction_domain(
         self,
         num_theta: int = 32,
-        n1: int = 1,
-        n2: int = 2,
-        n3: int = 15,
-        n4: int = 10,
-        n5: int = 3,
-        n6: int = 4,
-        n: t.Optional[int] = None,
-        type1: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type2: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type3: t.Literal['linear', 'geometric', 'quadratic'] = 'geometric',
-        type4: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type5: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
-        type6: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        num_1: int = 1,
+        num_2: int = 2,
+        num_3: int = 15,
+        num_4: int = 10,
+        num_5: int = 3,
+        num_6: int = 4,
+        num: t.Optional[int] = None,
+        type_1: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_2: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_3: t.Literal['linear', 'geometric', 'quadratic'] = 'geometric',
+        type_4: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_5: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
+        type_6: t.Literal['linear', 'geometric', 'quadratic'] = 'linear',
     ) -> s_res.NMMInteractionDomain:
         """Calculates the NMM interaction domain.
 
         Args:
-        num_theta (int) Number of discretization of angle of NA
-            (Optional, Default = 32)
-        n1: (int) number of strain profiles in field 1 (Optional, default = 1)
-        n2: (int) number of strain profiles in field 2 (Optional, default = 2)
-        n3: (int) number of strain profiles in field 3 (Optional, default = 15)
-        n4: (int) number of strain profiles in field 4 (Optional, default = 10)
-        n5: (int) number of strain profiles in field 5 (Optional, default = 3)
-        n6: (int) number of strain profiles in field 6 (Optional, default = 4)
-        n: (int) total number of strain profiles (Optional, default = None)
-            If specified n and n1..n6 the total number of n may be different.
-        type1: (literal) type of spacing for field 1
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type2: (literal) type of spacing for field 2
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type3: (literal) type of spacing for field 3
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'geometric')
-        type4: (literal) type of spacing for field 4
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type5: (literal) type of spacing for field 5
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
-        type6: (literal) type of spacing for field 6
-            'linear' for a linear spacing 'geometric' for a geometric spacing
-            (Optional default = 'linear')
+        num_theta (int): Number of discretization of angle of neutral axis
+            (Optional, Default = 32).
+        num_1 (int): Number of strain profiles in field 1
+            (Optional, default = 1).
+        num_2 (int): Number of strain profiles in field 2
+            (Optional, default = 2).
+        num_3 (int): Number of strain profiles in field 3
+            (Optional, default = 15).
+        num_4 (int): Number of strain profiles in field 4
+            (Optional, default = 10).
+        num_5 (int): Number of strain profiles in field 5
+            (Optional, default = 3).
+        num_6 (int): Number of strain profiles in field 6
+            (Optional, default = 4).
+        num (int): Total number of strain profiles (Optional, default = None).
+            If specified num and num_1, ..., num_6 the total number of num
+            may be different.
+        type_1 (literal): Type of spacing for field 1.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_2 (literal): Type of spacing for field 2.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_3 (literal): Type of spacing for field 3.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_4 (literal): Type of spacing for field 4.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_5 (literal): Type of spacing for field 5.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
+        type_6 (literal): Type of spacing for field 6.
+            'linear' for a linear spacing, 'geometric' for a geometric spacing
+            'quadratic' for a quadratic spacing (Optional default = 'linear').
 
         Return:
         (NMMInteractionDomain)
@@ -1092,20 +1166,13 @@ class GenericSectionCalculator(SectionCalculator):
         res = s_res.NMMInteractionDomain()
         res.num_theta = num_theta
 
-        # Process n
-        if n is not None:
-            n1_attempt = int(n / 35 * 1)
-            n2_attempt = int(n / 35 * 2)
-            n3_attempt = int(n / 35 * 15)
-            n4_attempt = int(n / 35 * 10)
-            n5_attempt = int(n / 35 * 3)
-            n6_attempt = int(n / 35 * 4)
-            n1 = max(n1_attempt, n1)
-            n2 = max(n2_attempt, n2)
-            n3 = max(n3_attempt, n3)
-            n4 = max(n4_attempt, n4)
-            n5 = max(n5_attempt, n5)
-            n6 = max(n6_attempt, n6)
+        # Process num if given.
+        if num is not None:
+            num_1, num_2, num_3, num_4, num_5, num_6 = (
+                self._process_num_strain_profiles(
+                    num, num_1, num_2, num_3, num_4, num_5, num_6
+                )
+            )
 
         # cycle for all n_thetas
         thetas = np.linspace(0, np.pi * 2, num_theta)
@@ -1115,18 +1182,18 @@ class GenericSectionCalculator(SectionCalculator):
             # Get ultimate strain profiles for theta angle
             strain = self._compute_ultimate_strain_profiles(
                 theta=theta,
-                n1=n1,
-                n2=n2,
-                n3=n3,
-                n4=n4,
-                n5=n5,
-                n6=n6,
-                type1=type1,
-                type2=type2,
-                type3=type3,
-                type4=type4,
-                type5=type5,
-                type6=type6,
+                num_1=num_1,
+                num_2=num_2,
+                num_3=num_3,
+                num_4=num_4,
+                num_5=num_5,
+                num_6=num_6,
+                type_1=type_1,
+                type_2=type_2,
+                type_3=type_3,
+                type_4=type_4,
+                type_5=type_5,
+                type_6=type_6,
             )
             strains = np.vstack((strains, strain))
 

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -804,6 +804,7 @@ class GenericSectionCalculator(SectionCalculator):
                     geo=self.section.geometry,
                     strain=strain,
                     tri=self.triangulated_data,
+                    mesh_size=self.mesh_size,
                 )
             )
             if self.triangulated_data is None:

--- a/tests/test_core/test_generic_section.py
+++ b/tests/test_core/test_generic_section.py
@@ -43,16 +43,26 @@ def test_rectangular_section():
 
     assert math.isclose(sec.gross_properties.area, 200 * 400)
 
+    # Compute max / min axial load
+    n_max_marin = sec.section_calculator.n_max
+    n_min_marin = sec.section_calculator.n_min
+
     # Compute bending strength
     res_marin = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
+
+    # Use integrate_strain_response
+    N, My, Mz = sec.section_calculator.integrate_strain_profile(
+        (res_marin.eps_a, res_marin.chi_y, res_marin.chi_z)
+    )
+
+    assert math.isclose(N, res_marin.n)
+    assert math.isclose(My, res_marin.m_y)
+    assert math.isclose(Mz, res_marin.m_z)
 
     # Compute moment curvature
     res_mc_marin = sec.section_calculator.calculate_moment_curvature(
         theta=0, n=0
     )
-
-    n_min_marin = sec.section_calculator.n_min
-    n_max_marin = sec.section_calculator.n_max
 
     # Use fiber integration
     sec = GenericSection(geo, integrator='Fiber', mesh_size=0.0001)
@@ -435,3 +445,44 @@ def test_refined_moment_curvature():
     # Assert
     assert len(res_more_points.chi_y) == 48
     assert math.isclose(res_large_chi_first.chi_y[0], chi_yield / 10)
+
+
+def test_refined_mn_domain():
+    """Test overriding defaults when calculating moment-curvature."""
+    # Create materials to use
+    concrete = ConcreteMC2010(25)
+    steel = ReinforcementMC2010(fyk=450, Es=210000, ftk=450, epsuk=0.0675)
+
+    # The section
+    poly = Polygon(((0, 0), (200, 0), (200, 400), (0, 400)))
+    geo = SurfaceGeometry(poly, concrete)
+    geo = add_reinforcement_line(geo, (40, 40), (160, 40), 16, steel, n=4)
+    geo = add_reinforcement_line(geo, (40, 360), (160, 360), 16, steel, n=4)
+    geo = geo.translate(-100, -200)
+
+    # Create the section
+    sec = GenericSection(geo, integrator='fiber')
+
+    # Calculate default moment-curvature relation
+    res_default = sec.section_calculator.calculate_nm_interaction_domain()
+
+    # Specify more discretized domain
+    res_refined = sec.section_calculator.calculate_nm_interaction_domain(
+        num=100
+    )
+
+    # Specify detailed discretization for each field
+    res_detailed = sec.section_calculator.calculate_nm_interaction_domain(
+        num_1=2,
+        num_2=10,
+        num_3=40,
+        num_4=40,
+        num_5=10,
+        num_6=5,
+        type_4='geometric',
+    )
+
+    # Assertion
+    assert len(res_default.strains) == 35
+    assert len(res_refined.strains) >= 0.9 * 100
+    assert len(res_detailed.strains) == 107

--- a/tests/test_core/test_steel_sections.py
+++ b/tests/test_core/test_steel_sections.py
@@ -252,7 +252,7 @@ def test_section_get_polygon(cls, name):
     steel = ElasticPlastic(E=Es, fy=fy, eps_su=eps_su)
 
     # Create geometry
-    geo = CompoundGeometry([SurfaceGeometry(cls.get_polygon(name), steel)])
+    geo = SurfaceGeometry(cls.get_polygon(name), steel)
     sec = GenericSection(geo)
 
     # Compute expected values


### PR DESCRIPTION
This PR addresses the issues in #156.

For functions `calculate_nm_interaction_domain` and `calculate_nmm_interaction_domain` the API was extended permitting a finer control on discretization of strain profiles.
By default a reasonable discretization is proposed. The user can specified the number of discretizations for each failure field (from 1 to 6) and eventually the typology of spacing. The supported spacing rules are: linear, geometric, quadratic.

For instance, setting all numbers to 1:
```
mn_results = section.section_calculator.calculate_nm_interaction_domain(n1=1,n2=1,n3=1,n4=1,n5=1,n6=1)
```

Leads to the following result in MN domain:

![image](https://github.com/user-attachments/assets/8697b767-d81c-44ea-9043-01f17bdc7c5b)

The points are corresponding to ultimate strain profiles shown in the following:
![image](https://github.com/user-attachments/assets/d67841d5-94fd-49cb-9c22-82537c61ac71)


By default all fields are discretized linearly, except field 3 that is discretized geometrically:

![image](https://github.com/user-attachments/assets/2b1354fd-8a06-415b-b4e7-c024fe7bbc5d)

Leading to a nicer discretization in the N space:

![image](https://github.com/user-attachments/assets/10f5af73-06b4-43ec-86a2-66679a069f4f)
