### PR TITLE
docs: describe versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ Read the [quickstart guide](https://fib-international.github.io/structuralcodes/
 ## Contribution guidelines
 
 Check out our docs for how to get started [contributing](https://fib-international.github.io/structuralcodes/contributing/) to StructuralCodes.
+
+## Versioning
+
+Check out our docs to see how we handle [versioning](https://fib-international.github.io/structuralcodes/versioning/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Examples <examples/index>
 API reference <api/index>
 Theory reference <theory/index>
 Contributing <contributing/index>
+Versioning <versioning/index>
 
 :::
 

--- a/docs/versioning/index.md
+++ b/docs/versioning/index.md
@@ -1,0 +1,19 @@
+(versioning)=
+# Versioning
+
+## General
+
+StructuralCodes does not yet have a stable API. This does not mean that you should not use the library for solving your design problems, but that there are more features to come, and that some of these new features might be implemented in ways that break existing behaviour.
+
+Until then, StructuralCodes will use a custom versioning scheme that uses the __minor__ version number for breaking changes, and the __patch__ version number for other changes.
+
+## Version changes
+
+A __patch__ version number increase, for example from `0.0.1` to `0.0.2`, occurs when:
+- Bugs are fixed.
+- New features are added in a backwards compatible manner.
+
+A __minor__ version number increase, for example from `0.0.2` to `0.1.0`, occurs when:
+- Changes are introduced in a backwards incompatible manner.
+
+A __major__ version number increase to `1.0.0` indicates that the API is stable, and that [semantic versioning](https://semver.org/) applies from here.


### PR DESCRIPTION
Add a description of how we handle versioning in the docs. In short we say that the API of StructuralCodes is not yet stable. When the API is stable we will increase the major version to 1.0.0. Until then, we will indicate backwards incompatible changes by an increase of the minor version number.

This is loosly inspired by the current versioning scheme used by [Ruff](https://docs.astral.sh/ruff/versioning/).