### PR TITLE
first attempt of plot

### DIFF
--- a/structuralcodes/core/_section_results.py
+++ b/structuralcodes/core/_section_results.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations  # To have clean hints of ArrayLike in docs
 
+import typing as t
 from dataclasses import dataclass, field, fields
 
+import matplotlib.pyplot as plt
+from matplotlib.axis import Axis
+from matplotlib.figure import Figure
 from numpy.typing import ArrayLike
 
 
@@ -197,6 +201,33 @@ class NMInteractionDomain:
     m_z: ArrayLike = None  # Moments Mz
 
     strains: ArrayLike = None
+
+    def get_plot(
+        self,
+        horizontal_axis: t.Literal['n', 'my', 'mz'] = 'n',
+        vertical_axis: t.Literal['n', 'my', 'mz'] = 'my',
+        ax: t.Optional[Axis] = None,
+    ) -> t.Tuple[Figure, Axis]:
+        """Retuns figure and axes handlers for a matplotlib plot."""
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.get_figure()
+        if horizontal_axis == 'n':
+            x = self.n
+        elif horizontal_axis == 'my':
+            x = self.m_y
+        elif horizontal_axis == 'mz':
+            x = self.m_z
+        if vertical_axis == 'n':
+            y = self.n
+        elif vertical_axis == 'my':
+            y = self.m_y
+        elif vertical_axis == 'mz':
+            y = self.m_z
+        ax.plot(x, y)
+        ax.set(xlabel=horizontal_axis, ylabel=vertical_axis)
+        return fig, ax
 
 
 @dataclass


### PR DESCRIPTION
This is just a first attempt.

The following code creates the related plot:
```
# Try new plot functionality
res_1 = section.section_calculator.calculate_nm_interaction_domain(theta=0)
res_2 = section.section_calculator.calculate_nm_interaction_domain(theta=0+np.pi)
fig, ax = res_1.get_plot(vertical_axis='my', horizontal_axis='n')
fig, ax = res_2.get_plot(ax=ax, vertical_axis='my', horizontal_axis='n')
```
![image](https://github.com/user-attachments/assets/f0eebb0e-1c88-455b-95dd-725063ef18cf)


Even this simple case it shows that is somehow complicated to do something that covers all common cases.
For instance:
- we generally plot n as x axis while my as y axes, while you generally do the opposite (I did something to cover it)
- the nm interaction domain can be applied to different angles, so a 2d diagram does not cover a generic case that should be plot in 3d axes as the following example:

```
fig = plt.figure()
ax = fig.add_subplot(111, projection='3d')
theta = np.linspace(0,np.pi,9)
for th in theta:
    res = section.section_calculator.calculate_nm_interaction_domain(theta=th)
    ax.plot(res.n*1e-3, res.m_y*1e-6, res.m_z*1e-6)
    res = section.section_calculator.calculate_nm_interaction_domain(theta=th + np.pi)
    ax.plot(res.n*1e-3, res.m_y*1e-6, res.m_z*1e-6)
ax.set_xlim(xmin=section.section_calculator.n_min*1e-3,xmax=section.section_calculator.n_max*1e-3)
ax.set_ylim(ymin=-600, ymax=600)
ax.set_zlim(zmin=-600, zmax=600)
ax.set_xlabel('N [kN]')
ax.set_ylabel('My [kNm]')
ax.set_zlabel('Mz [kNm]')
```
which produces the following plot:
![image](https://github.com/user-attachments/assets/2cc97816-c554-46bc-a810-beb9c142b1ba)

For dealing with this issue we could say that `NMInteractionDomain` class has a `get_plot` that is the 2d plot as I have implemented it and a `get_plot_3d' that contains a 3d version of it? Alternatively we could ask instead of `vertical_axis` and `horizontal_axis` the arguments `x_axis` and `y_axis` adding an `Optional` `z_axis` by default set to None. If specified it will create the 3d plot, otherwise the 2d plot.

- scaling: if we used as units N, mm the moments will be in Nmm. For this reason sometimes the user may want to scale the results, like the following code:

```
res_1 = section.section_calculator.calculate_nm_interaction_domain(theta=0)
res_2 = section.section_calculator.calculate_nm_interaction_domain(theta=0+np.pi)

fig_mn, ax_mn = plt.subplots()
ax_mn.plot(res_1.n / 1000, res_1.m_y *1e-6)
ax_mn.plot(res_2.n / 1000, res_2.m_y *1e-6)
ax_mn.set_xlabel('N [kN]')
ax_mn.set_ylabel('M [kNm]')
ax_mn.axvline(0.0, linestyle='--', color ='k')
ax_mn.axhline(0.0, linestyle='--', color ='k')
ax_mn.set_xlim([-6500, 1500])
ax_mn.xaxis.set_inverted(True)
```
which produces the following picture:
![image](https://github.com/user-attachments/assets/743bdc52-4fd3-4b37-bb8a-0697a1a8c1a5)

for this last problem maybe we can insert `scale_x` and `scale_y` arguments to the function `get_plot`?

What do you think?
