### PR TITLE
fix: swap order of strain limits returned from get_ultimate_strain

### DIFF
--- a/structuralcodes/core/base.py
+++ b/structuralcodes/core/base.py
@@ -101,7 +101,7 @@ class ConstitutiveLaw(abc.ABC):
     @abc.abstractmethod
     def get_ultimate_strain(self) -> t.Tuple[float, float]:
         """Each constitutive law should provide a method to return the
-        ultimate strain (positive and negative).
+        ultimate strain (negative and positive).
         """
 
     def preprocess_strains_with_limits(self, eps: ArrayLike) -> ArrayLike:
@@ -109,7 +109,7 @@ class ConstitutiveLaw(abc.ABC):
         near to ultimate strain limits to exactly ultimate strain limit.
         """
         eps = np.atleast_1d(np.asarray(eps))
-        eps_max, eps_min = self.get_ultimate_strain()
+        eps_min, eps_max = self.get_ultimate_strain()
 
         idxs = np.isclose(eps, np.zeros_like(eps) + eps_max, atol=1e-6)
         eps[idxs] = eps_max
@@ -138,7 +138,7 @@ class ConstitutiveLaw(abc.ABC):
             # All values are zero for x > 0
             return None
 
-        eps_max, eps_min = self.get_ultimate_strain()
+        eps_min, eps_max = self.get_ultimate_strain()
         eps_max = min(eps_max, 1)
         # Analise positive branch
         eps = np.linspace(0, eps_max, 10000)

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -291,14 +291,14 @@ class GenericSectionCalculator(SectionCalculator):
         for g in geom.geometries + geom.point_geometries:
             for other_g in geom.geometries + geom.point_geometries:
                 # if g != other_g:
-                eps_p = g.material.get_ultimate_strain(yielding=yielding)[0]
+                eps_p = g.material.get_ultimate_strain(yielding=yielding)[1]
                 if isinstance(g, SurfaceGeometry):
                     y_p = g.polygon.bounds[1]
                 elif isinstance(g, PointGeometry):
                     y_p = g._point.coords[0][1]
                 eps_n = other_g.material.get_ultimate_strain(
                     yielding=yielding
-                )[1]
+                )[0]
                 if isinstance(other_g, SurfaceGeometry):
                     y_n = other_g.polygon.bounds[3]
                 elif isinstance(other_g, PointGeometry):

--- a/tests/test_core/test_constitutive_laws.py
+++ b/tests/test_core/test_constitutive_laws.py
@@ -30,8 +30,8 @@ def test_elastic_floats(E, strain, expected):
     """Test the elastic material."""
     assert math.isclose(Elastic(E).get_stress(strain)[0], expected)
     assert math.isclose(Elastic(E).get_tangent(strain)[0], E)
-    assert math.isclose(Elastic(E).get_ultimate_strain()[0], 100)
-    assert math.isclose(Elastic(E).get_ultimate_strain()[1], -100)
+    assert math.isclose(Elastic(E).get_ultimate_strain()[0], -100)
+    assert math.isclose(Elastic(E).get_ultimate_strain()[1], 100)
 
 
 @pytest.mark.parametrize(
@@ -46,8 +46,8 @@ def test_elastic_set_ultimate_strain_float(E, eps_su):
     """Test elastic material set ultimate strain with a float."""
     material = Elastic(E)
     material.set_ultimate_strain(eps_su)
-    assert math.isclose(material.get_ultimate_strain()[0], eps_su)
-    assert math.isclose(material.get_ultimate_strain()[1], -eps_su)
+    assert math.isclose(material.get_ultimate_strain()[0], -eps_su)
+    assert math.isclose(material.get_ultimate_strain()[1], eps_su)
 
 
 @pytest.mark.parametrize(
@@ -62,8 +62,8 @@ def test_elastic_set_ultimate_strain_tuple(E, eps_su):
     """Test elastic material set ultimate strain with a tuple."""
     material = Elastic(E)
     material.set_ultimate_strain(eps_su=eps_su)
-    assert math.isclose(material.get_ultimate_strain()[0], max(eps_su))
-    assert math.isclose(material.get_ultimate_strain()[1], min(eps_su))
+    assert math.isclose(material.get_ultimate_strain()[0], min(eps_su))
+    assert math.isclose(material.get_ultimate_strain()[1], max(eps_su))
 
 
 @pytest.mark.parametrize(
@@ -276,8 +276,8 @@ def test_user_defined_floats(x, y, flag, strain, expected):
     )
     xmin = x[0] if x[0] < 0 else -x[-1]
     xmax = x[-1]
-    assert math.isclose(UserDefined(x, y).get_ultimate_strain()[0], xmax)
-    assert math.isclose(UserDefined(x, y).get_ultimate_strain()[1], xmin)
+    assert math.isclose(UserDefined(x, y).get_ultimate_strain()[0], xmin)
+    assert math.isclose(UserDefined(x, y).get_ultimate_strain()[1], xmax)
 
     with pytest.raises(ValueError) as excinfo:
         UserDefined(x[:-1], y)
@@ -301,8 +301,8 @@ def test_userdefined_set_ultimate_strain_float(E, fy, eps_su):
     y = [-fy, 0, fy]
     material = UserDefined(x=x, y=y)
     material.set_ultimate_strain(eps_su)
-    assert math.isclose(material.get_ultimate_strain()[0], eps_su)
-    assert math.isclose(material.get_ultimate_strain()[1], -eps_su)
+    assert math.isclose(material.get_ultimate_strain()[0], -eps_su)
+    assert math.isclose(material.get_ultimate_strain()[1], eps_su)
 
 
 @pytest.mark.parametrize(
@@ -319,8 +319,8 @@ def test_userdefined_set_ultimate_strain_tuple(E, fy, eps_su):
     y = [-fy, 0, fy]
     material = UserDefined(x=x, y=y)
     material.set_ultimate_strain(eps_su=eps_su)
-    assert math.isclose(material.get_ultimate_strain()[0], max(eps_su))
-    assert math.isclose(material.get_ultimate_strain()[1], min(eps_su))
+    assert math.isclose(material.get_ultimate_strain()[0], min(eps_su))
+    assert math.isclose(material.get_ultimate_strain()[1], max(eps_su))
 
 
 @pytest.mark.parametrize(
@@ -397,11 +397,11 @@ def test_sargin(fc, eps_c1, eps_cu1, k):
     assert_allclose(tan_computed, tan_expected)
 
     # Test getting ultimate strain
-    eps_max, eps_min = law.get_ultimate_strain()
+    eps_min, eps_max = law.get_ultimate_strain()
     assert math.isclose(eps_min, eps_cu1)
     assert math.isclose(eps_max, 100)
 
-    eps_max, eps_min = law.get_ultimate_strain(yielding=True)
+    eps_min, eps_max = law.get_ultimate_strain(yielding=True)
     assert math.isclose(eps_min, eps_c1)
     assert math.isclose(eps_max, 100)
 
@@ -457,11 +457,11 @@ def test_popovics(fc, eps_c, eps_cu):
     assert_allclose(tan_computed, tan_expected)
 
     # Test getting ultimate strain
-    eps_max, eps_min = law.get_ultimate_strain()
+    eps_min, eps_max = law.get_ultimate_strain()
     assert math.isclose(eps_min, -eps_cu)
     assert math.isclose(eps_max, 100)
 
-    eps_max, eps_min = law.get_ultimate_strain(yielding=True)
+    eps_min, eps_max = law.get_ultimate_strain(yielding=True)
     assert math.isclose(eps_min, -eps_c)
     assert math.isclose(eps_max, 100)
 
@@ -508,10 +508,10 @@ def test_bilinearcompression(fc, eps_c, eps_cu):
     assert_allclose(tan_computed, tan_expected)
 
     # Test getting ultimate strain
-    eps_max, eps_min = law.get_ultimate_strain()
+    eps_min, eps_max = law.get_ultimate_strain()
     assert math.isclose(eps_min, -eps_cu)
     assert math.isclose(eps_max, 100)
 
-    eps_max, eps_min = law.get_ultimate_strain(yielding=True)
+    eps_min, eps_max = law.get_ultimate_strain(yielding=True)
     assert math.isclose(eps_min, -eps_c)
     assert math.isclose(eps_max, 100)


### PR DESCRIPTION
The `get_ultimate_strain` method on `ConstitutiveLaw`s returns a tuple of strains. In the current implementation, it returns the positive strain first, and then the negative strain. It is perhaps more intuitive if we swap these, so that the returned strain limits are from left to right in a typical stress-strain diagram, or from low to high with respect to value. This is an attempt to swap the values.