### PR TITLE
fix: interaction domain results

### DIFF
--- a/docs/api/sections/section_calculator.md
+++ b/docs/api/sections/section_calculator.md
@@ -45,13 +45,32 @@
 ```
 
 ```{eval-rst}
-.. autoclass:: structuralcodes.core._section_results.NMMInteractionDomain
+.. autoclass:: structuralcodes.core._section_results.NMInteractionDomain
+
+    .. autoproperty:: n
+    .. autoproperty:: m_y
+    .. autoproperty:: e_a
+    .. autoproperty:: k_y
 ```
 
 ```{eval-rst}
-.. autoclass:: structuralcodes.core._section_results.NMInteractionDomain
+.. autoclass:: structuralcodes.core._section_results.NMMInteractionDomain
+
+    .. autoproperty:: n
+    .. autoproperty:: m_y
+    .. autoproperty:: m_z
+    .. autoproperty:: e_a
+    .. autoproperty:: k_y
+    .. autoproperty:: k_z
 ```
 
 ```{eval-rst}
 .. autoclass:: structuralcodes.core._section_results.MMInteractionDomain
+
+    .. autoproperty:: n
+    .. autoproperty:: m_y
+    .. autoproperty:: m_z
+    .. autoproperty:: e_a
+    .. autoproperty:: k_y
+    .. autoproperty:: k_z
 ```

--- a/structuralcodes/core/_section_results.py
+++ b/structuralcodes/core/_section_results.py
@@ -180,11 +180,11 @@ class InteractionDomain:
 
     Attributes:
         strains (numpy.Array): A numpy array with shape (n, 3) containing ea,
-        ky and kz.
+            ky and kz.
         forces (numpy.Array): A numpy array with shape (n, 3) containing n, my
-        and mz.
+            and mz.
         field_num (numpy.Array): a numpy array with shape (n,) containing a
-        number between 1 and 6 indicating the failure field.
+            number between 1 and 6 indicating the failure field.
     """
 
     # array with shape (n,3) containing ea, ky, kz:

--- a/structuralcodes/core/_section_results.py
+++ b/structuralcodes/core/_section_results.py
@@ -190,36 +190,49 @@ class InteractionDomain:
     strains: ArrayLike = None
     # array with shape(n,3) containing N, My, Mz
     forces: ArrayLike = None
-class NMMInteractionDomain:
+    # array with shape(n,) containing the field number from 1 to 6
+    field_num: ArrayLike = None
 
     @property
     def n(self):
         """Return axial force."""
+        if self.forces is None:
+            return None
         return self.forces[:, 0]
 
     @property
     def m_y(self):
         """Return my."""
+        if self.forces is None:
+            return None
         return self.forces[:, 1]
 
     @property
     def m_z(self):
         """Return mz."""
+        if self.forces is None:
+            return None
         return self.forces[:, 2]
 
     @property
     def e_a(self):
         """Return ea."""
+        if self.strains is None:
+            return None
         return self.strains[:, 0]
 
     @property
     def k_y(self):
         """Return ky."""
+        if self.strains is None:
+            return None
         return self.strains[:, 1]
 
     @property
     def k_z(self):
         """Return kz."""
+        if self.strains is None:
+            return None
         return self.strains[:, 2]
 
 
@@ -244,5 +257,4 @@ class MMInteractionDomain(InteractionDomain):
     """Class for storing the MM interaction domain results."""
 
     num_theta: float = 0  # number of discretizations along the angle
-    n: float = 0  # axial load
     theta: ArrayLike = None  # Array with shape (n,) containing the angle of NA

--- a/structuralcodes/core/_section_results.py
+++ b/structuralcodes/core/_section_results.py
@@ -178,12 +178,13 @@ class UltimateBendingMomentResults:
 class InteractionDomain:
     """Class for storing common data on all interaction domain results.
 
-    Data contained:
-
-    strains: a numpy array with shape (n, 3) containing ea, ky and kz.
-    forces: a numpy array with shape (n, 3) containing n, my and mz.
-    field_num: a numpy array with shape (n,) cotaning a number between
-    1 and 6 indicating the failure field.
+    Attributes:
+        strains (numpy.Array): A numpy array with shape (n, 3) containing ea,
+        ky and kz.
+        forces (numpy.Array): A numpy array with shape (n, 3) containing n, my
+        and mz.
+        field_num (numpy.Array): a numpy array with shape (n,) containing a
+        number between 0 and 6 indicating the failure field.
     """
 
     # array with shape (n,3) containing ea, ky, kz:

--- a/structuralcodes/core/_section_results.py
+++ b/structuralcodes/core/_section_results.py
@@ -175,37 +175,74 @@ class UltimateBendingMomentResults:
 
 
 @dataclass
+class InteractionDomain:
+    """Class for storing common data on all interaction domain results.
+
+    Data contained:
+
+    strains: a numpy array with shape (n, 3) containing ea, ky and kz.
+    forces: a numpy array with shape (n, 3) containing n, my and mz.
+    field_num: a numpy array with shape (n,) cotaning a number between
+    1 and 6 indicating the failure field.
+    """
+
+    # array with shape (n,3) containing ea, ky, kz:
+    strains: ArrayLike = None
+    # array with shape(n,3) containing N, My, Mz
+    forces: ArrayLike = None
 class NMMInteractionDomain:
+
+    @property
+    def n(self):
+        """Return axial force."""
+        return self.forces[:, 0]
+
+    @property
+    def m_y(self):
+        """Return my."""
+        return self.forces[:, 1]
+
+    @property
+    def m_z(self):
+        """Return mz."""
+        return self.forces[:, 2]
+
+    @property
+    def e_a(self):
+        """Return ea."""
+        return self.strains[:, 0]
+
+    @property
+    def k_y(self):
+        """Return ky."""
+        return self.strains[:, 1]
+
+    @property
+    def k_z(self):
+        """Return kz."""
+        return self.strains[:, 2]
+
+
+@dataclass
+class NMMInteractionDomain(InteractionDomain):
     """Class for storing the NMM interaction domain results."""
 
     num_theta: int = 0  # number of discretizations along the angle
     num_axial: int = 0  # number of discretizations along axial load axis
 
-    strains: ArrayLike = None  # array with shape (n,3) containing strains
-    forces: ArrayLike = None  # array with shape(n,3) containing N, My, Mz
-
 
 @dataclass
-class NMInteractionDomain:
+class NMInteractionDomain(InteractionDomain):
     """Class for storing the NM interaction domain results."""
 
     theta: float = 0  # the inclination of n.a.
     num_axial: float = 0  # number of discretizations along axial load axis
 
-    n: ArrayLike = None  # Axial loads
-    m_y: ArrayLike = None  # Moments My
-    m_z: ArrayLike = None  # Moments Mz
-
-    strains: ArrayLike = None
-
 
 @dataclass
-class MMInteractionDomain:
+class MMInteractionDomain(InteractionDomain):
     """Class for storing the MM interaction domain results."""
 
     num_theta: float = 0  # number of discretizations along the angle
     n: float = 0  # axial load
-
-    theta: ArrayLike = None  # Angle theta respect axis Y
-    m_y: ArrayLike = None  # Moments My
-    m_z: ArrayLike = None  # Moments Mz
+    theta: ArrayLike = None  # Array with shape (n,) containing the angle of NA

--- a/structuralcodes/core/_section_results.py
+++ b/structuralcodes/core/_section_results.py
@@ -184,7 +184,7 @@ class InteractionDomain:
         forces (numpy.Array): A numpy array with shape (n, 3) containing n, my
         and mz.
         field_num (numpy.Array): a numpy array with shape (n,) containing a
-        number between 0 and 6 indicating the failure field.
+        number between 1 and 6 indicating the failure field.
     """
 
     # array with shape (n,3) containing ea, ky, kz:

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -913,7 +913,7 @@ class GenericSectionCalculator(SectionCalculator):
             )
 
         # Get ultimate strain profiles for theta angle
-        strains = self._compute_ultimate_strain_profiles(
+        strains, field_num = self._compute_ultimate_strain_profiles(
             theta=theta,
             num_1=num_1,
             num_2=num_2,
@@ -949,6 +949,7 @@ class GenericSectionCalculator(SectionCalculator):
         # Save to results
         res.strains = strains
         res.forces = forces
+        res.field_num = field_num
 
         return res
 
@@ -1045,6 +1046,9 @@ class GenericSectionCalculator(SectionCalculator):
             raise ValueError(f'Type of spacing not known: {type}')
 
         # For generation of fields 1 and 2 pivot on positive strain
+        field_num = np.repeat(
+            [1, 2, 3, 4, 5, 6], [num_1, num_2, num_3, num_4, num_5, num_6]
+        )
         # Field 1: pivot on positive strain
         eps_n = _np_space(eps_p_b, 0, num_1, type_1, endpoint=False)
         eps_p = np.zeros_like(eps_n) + eps_p_b
@@ -1104,7 +1108,7 @@ class GenericSectionCalculator(SectionCalculator):
         T = np.array([[cos(theta), -sin(theta)], [sin(theta), cos(theta)]])
         components = np.vstack((kappa_y, np.zeros_like(kappa_y)))
         rotated_components = T @ components
-        return np.column_stack((eps_a, rotated_components.T))
+        return np.column_stack((eps_a, rotated_components.T)), field_num
 
     def calculate_nmm_interaction_domain(
         self,
@@ -1177,7 +1181,7 @@ class GenericSectionCalculator(SectionCalculator):
         strains = np.empty((0, 3))
         for theta in thetas:
             # Get ultimate strain profiles for theta angle
-            strain = self._compute_ultimate_strain_profiles(
+            strain, field_num = self._compute_ultimate_strain_profiles(
                 theta=theta,
                 num_1=num_1,
                 num_2=num_2,
@@ -1213,6 +1217,7 @@ class GenericSectionCalculator(SectionCalculator):
         # Save to results
         res.strains = strains
         res.forces = forces
+        res.field_num = field_num
 
         return res
 


### PR DESCRIPTION
In this PR I refactored slightly the Interaction Domain Results in order to be consistent.

I am proposing to keep strains and forces arrays as the real data (this can be helpful for dealing with the data in an efficient way for further processing of the data) plus creating properties for returning easily for the user the specific forces (n, m_y, m_z) and strain (ea, k_y, k_z).

For instance, this code creates and plots an interaction domain of a rectangular cross section.

```
# Imports
import matplotlib.pyplot as plt
import numpy as np
from shapely import Polygon
from structuralcodes.codes import set_design_code
from structuralcodes.geometry import SurfaceGeometry
from structuralcodes.materials.concrete import create_concrete
from structuralcodes.materials.reinforcement import create_reinforcement
from structuralcodes.sections import GenericSection, add_reinforcement_line
# Set parameters
height = 400
width = 200
cover = 32
diameter_rebars = 16
n_bars = 4
fck = 25
fyk = 450 
ftk_rebars = fyk  # 520 / 1.15
Es = 200000
eps_uk = 0.0075
d1 = cover + diameter_rebars / 2
# Materials
set_design_code('ec2_2004')
concrete = create_concrete(fck)
reinforcement = create_reinforcement(fyk=fyk, Es=Es, ftk=ftk_rebars, epsuk=eps_uk)
# Assemble section
concrete_rectangle = Polygon(
    (
        (-width / 2, -height / 2),
        (width / 2, -height / 2),
        (width / 2, height / 2),
        (-width / 2, height / 2),
    )
)

concrete_geometry = SurfaceGeometry(concrete_rectangle, concrete)

z_value = -height / 2 + d1

for z_value in (-height / 2 + d1, 
                height / 2 - d1,
                ):
    concrete_geometry = add_reinforcement_line(
        geo=concrete_geometry,
        coords_i=(-width / 2 + d1, z_value),
        coords_j=(width / 2 - d1, z_value),
        diameter=diameter_rebars,
        material=reinforcement,
        n=n_bars,
    )
section = GenericSection(concrete_geometry, integrator='fiber', mesh_size=0.001)
# MN domain FIBER
res_1 = section.section_calculator.calculate_nm_interaction_domain(theta=0)
res_2 = section.section_calculator.calculate_nm_interaction_domain(theta=0+np.pi)

fig_mn, ax_mn = plt.subplots()
ax_mn.plot(res_1.m_y *1e-6,res_1.n / 1000)
ax_mn.plot(res_2.m_y *1e-6, res_2.n / 1000)
ax_mn.set_ylabel('N [kN]')
ax_mn.set_xlabel('M [kNm]')
ax_mn.axhline(0.0, linestyle='--', color ='k')
ax_mn.axvline(0.0, linestyle='--', color ='k')
```

will produce the following diagram:
![image](https://github.com/user-attachments/assets/b582d3fe-1c08-42fe-a0b6-dc6eea3e9634)

Moreover I included in the results the number of field of the failure strain profile from 1 (pure tension) to 6 (pure compression) to permit for instance separate plotting of the regions of interest. For instance, the following code:

```
# print field numbers
for f in [1,2,3,4,5,6]:
    ax_mn.plot(res_1.m_y[res_1.field_num == f]*1e-6, res_1.n[res_1.field_num==f]*1e-3,'-o')
    ax_mn.plot(res_2.m_y[res_2.field_num == f]*1e-6, res_2.n[res_2.field_num==f]*1e-3,'-o')
```
will produce the following diagram:
![image](https://github.com/user-attachments/assets/75951c09-36fd-4554-94f0-220d91ff3e60)

