### PR TITLE
feat: add kwarg group_label to add_reinforcement functions

### DIFF
--- a/structuralcodes/geometry/_reinforcement.py
+++ b/structuralcodes/geometry/_reinforcement.py
@@ -18,6 +18,7 @@ def add_reinforcement(
     coords: t.Tuple[float, float],
     diameter: float,
     material: t.Union[Material, ConstitutiveLaw],
+    group_label: t.Optional[str] = None,
 ) -> CompoundGeometry:
     """Add a single bar given coordinate.
 
@@ -28,12 +29,16 @@ def add_reinforcement(
         diameter (float): The diameter of the reinforcement.
         material (Union(Material, ConstitutiveLaw)): A material or a
             constitutive law for the behavior of the reinforcement.
+        group_label (Optional(str)): A label for grouping several objects
+            (default is None).
 
     Returns:
         CompoundGeometry: A compound geometry with the original geometry and
         the reinforcement.
     """
-    bar = PointGeometry(Point(coords), diameter, material)
+    bar = PointGeometry(
+        Point(coords), diameter, material, group_label=group_label
+    )
     return geo + bar
 
 
@@ -47,6 +52,7 @@ def add_reinforcement_line(
     s: float = 0.0,
     first: bool = True,
     last: bool = True,
+    group_label: t.Optional[str] = None,
 ) -> CompoundGeometry:
     """Adds a set of bars distributed in a line.
 
@@ -66,6 +72,8 @@ def add_reinforcement_line(
             True).
         last (bool): Boolean indicating if placing the last bar (default =
             True).
+        group_label (Optional(str)): A label for grouping several objects
+            (default is None).
 
     Note:
         At least n or s should be greater than zero.
@@ -110,6 +118,10 @@ def add_reinforcement_line(
             continue
         coords = p1 + v * s * i
         geo = add_reinforcement(
-            geo, (coords[0], coords[1]), diameter, material
+            geo,
+            (coords[0], coords[1]),
+            diameter,
+            material,
+            group_label=group_label,
         )
     return geo

--- a/tests/test_core/test_geometry.py
+++ b/tests/test_core/test_geometry.py
@@ -23,6 +23,7 @@ from structuralcodes.materials.constitutive_laws import (
     ElasticPlastic,
     ParabolaRectangle,
 )
+from structuralcodes.materials.reinforcement import ReinforcementMC2010
 
 
 # Test create line
@@ -562,3 +563,89 @@ def test_property_reinforced_concrete(w, h, c):
         n=4,
     )
     assert geo_rc.reinforced_concrete
+
+
+def test_reinforcement_group_label_one():
+    """Test adding one reinforcement with a group label to a section."""
+    # Arrange
+    group_label = 'bottom-reinf'
+    width = 200
+    height = 500
+    cover = 50
+    diameter = 16
+
+    concrete = ConcreteMC2010(fck=35)
+    reinforcement = ReinforcementMC2010(
+        fyk=500, ftk=520, epsuk=0.05, Es=200000
+    )
+
+    geometry = SurfaceGeometry(
+        poly=Polygon(
+            (
+                (-width / 2, -height / 2),
+                (width / 2, -height / 2),
+                (width / 2, height / 2),
+                (-width / 2, height / 2),
+            )
+        ),
+        material=concrete,
+    )
+
+    # Act
+    geometry = add_reinforcement(
+        geometry,
+        (0, -height / 2 + cover),
+        diameter,
+        reinforcement,
+        group_label=group_label,
+    )
+    point_geometries = geometry.point_geometries
+
+    # Assert
+    assert len(point_geometries) == 1
+    assert point_geometries[0].group_label == group_label
+
+
+def test_reinforcement_group_label_line():
+    """Test adding reinforcement with a group label along a line."""
+    # Arrange
+    group_label = 'bottom-reinf'
+    width = 200
+    height = 500
+    cover = 50
+    diameter = 16
+    n_bars = 3
+
+    concrete = ConcreteMC2010(fck=35)
+    reinforcement = ReinforcementMC2010(
+        fyk=500, ftk=520, epsuk=0.05, Es=200000
+    )
+
+    geometry = SurfaceGeometry(
+        poly=Polygon(
+            (
+                (-width / 2, -height / 2),
+                (width / 2, -height / 2),
+                (width / 2, height / 2),
+                (-width / 2, height / 2),
+            )
+        ),
+        material=concrete,
+    )
+
+    # Act
+    geometry = add_reinforcement_line(
+        geometry,
+        (-width / 2 + cover, -height / 2 + cover),
+        (width / 2 - cover, -height / 2 + cover),
+        diameter,
+        reinforcement,
+        n_bars,
+        group_label=group_label,
+    )
+    point_geometries = geometry.point_geometries
+
+    # Assert
+    assert len(point_geometries) == n_bars
+    for point in point_geometries:
+        assert point.group_label == group_label


### PR DESCRIPTION
Add the keyword argument `group_label` to the functions for adding reinforcement. This way, the created reinforcement is assigned the group label, and we prepare for other functions that can select based on the label.