### PR TITLE
fix: use also relative tolerance when checking calculated Iyz

### DIFF
--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -5,7 +5,6 @@ from __future__ import annotations  # To have clean hints of ArrayLike in docs
 import math
 import typing as t
 import warnings
-from math import cos, sin
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -577,7 +576,12 @@ class GenericSectionCalculator(SectionCalculator):
         """Rotate triangulated data of angle theta."""
         rotated_triangulated_data = []
         for tr in self.triangulated_data:
-            T = np.array([[cos(theta), -sin(theta)], [sin(theta), cos(theta)]])
+            T = np.array(
+                [
+                    [np.cos(theta), -np.sin(theta)],
+                    [np.sin(theta), np.cos(theta)],
+                ]
+            )
             coords = np.vstack((tr[0], tr[1]))
             coords_r = T @ coords
             rotated_triangulated_data.append(
@@ -639,7 +643,9 @@ class GenericSectionCalculator(SectionCalculator):
         )
 
         # Rotate back to section CRS TODO Check
-        T = np.array([[cos(theta), -sin(theta)], [sin(theta), cos(theta)]])
+        T = np.array(
+            [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
+        )
         M = T @ np.array([[My], [Mz]])
         if self.triangulated_data is not None:
             # Rotate back also triangulated data!
@@ -774,7 +780,12 @@ class GenericSectionCalculator(SectionCalculator):
                 geo=rotated_geom, strain=strain, tri=self.triangulated_data
             )
             # Rotate back to section CRS
-            T = np.array([[cos(theta), -sin(theta)], [sin(theta), cos(theta)]])
+            T = np.array(
+                [
+                    [np.cos(theta), -np.sin(theta)],
+                    [np.sin(theta), np.cos(theta)],
+                ]
+            )
             M = T @ np.array([[My], [Mz]])
             eps_a[i] = strain[0]
             my[i] = M[0, 0]
@@ -1109,7 +1120,9 @@ class GenericSectionCalculator(SectionCalculator):
         eps_a = eps_n - kappa_y * y_n
 
         # rotate back components to work in section CRS
-        T = np.array([[cos(theta), -sin(theta)], [sin(theta), cos(theta)]])
+        T = np.array(
+            [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
+        )
         components = np.vstack((kappa_y, np.zeros_like(kappa_y)))
         rotated_components = T @ components
         return np.column_stack((eps_a, rotated_components.T)), field_num

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations  # To have clean hints of ArrayLike in docs
 
+import math
 import typing as t
 import warnings
 from math import cos, sin
@@ -208,7 +209,9 @@ class GenericSectionCalculator(SectionCalculator):
             )
             # Change sign due to moment sign convention
             izz *= -1
-            if abs(abs(izy) - abs(iyz)) > 10:
+
+            # Check calculated cross moment
+            if not math.isclose(iyz, izy, rel_tol=1e-9, abs_tol=10):
                 error_str = 'Something went wrong with computation of '
                 error_str += f'moments of area: iyz = {iyz}, izy = {izy}.\n'
                 error_str += 'They should be equal but are not!'

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -209,8 +209,12 @@ class GenericSectionCalculator(SectionCalculator):
             # Change sign due to moment sign convention
             izz *= -1
 
+            # Compute reasonable value for absolute tolerance for checking iyz
+            rel_tol = 1e-9
+            abs_tol = 0.5 * (iyy + izz) * rel_tol
+
             # Check calculated cross moment
-            if not math.isclose(iyz, izy, rel_tol=1e-9, abs_tol=10):
+            if not math.isclose(iyz, izy, rel_tol=rel_tol, abs_tol=abs_tol):
                 error_str = 'Something went wrong with computation of '
                 error_str += f'moments of area: iyz = {iyz}, izy = {izy}.\n'
                 error_str += 'They should be equal but are not!'


### PR DESCRIPTION
In our calculation of the cross moment Iyz for generic sections, we raise a `RuntimeError` if the two ways of calculating the moment does not result in values that are close enough. In the current version we check only the absolute value of these results, but this is too strict if the section has a value of the cross moment significantly different from zero.

This is an attempt to liberalize the check by introducing a relative check in addition by using the `math.isclose` function. The absolute tolerance used in `isclose` is rather liberal, but the value is kept equal to the existing implementation.

Although beyond the scope of the PR, I have also changed `math.sin` and `math.cos` to the `numpy` versions of the functions to have a cleaner import block.