### PR TITLE
fix: reinforced concrete property

### DIFF
--- a/structuralcodes/geometry/_geometry.py
+++ b/structuralcodes/geometry/_geometry.py
@@ -557,6 +557,7 @@ class SurfaceGeometry:
             poly=affinity.translate(self.polygon, dx, dy),
             material=self.material,
             density=self._density,
+            concrete=self.concrete
         )
 
     def rotate(
@@ -584,6 +585,7 @@ class SurfaceGeometry:
             ),
             material=self.material,
             density=self._density,
+            concrete=self.concrete,
         )
 
     @staticmethod


### PR DESCRIPTION
When translating or rotating a SurfaceGeometry or CompoundGeometry we have to pass also the concrete argument to the init method.