### PR TITLE
fix: rotate strain in result from bending strength

### DIFF
--- a/structuralcodes/geometry/_geometry.py
+++ b/structuralcodes/geometry/_geometry.py
@@ -557,7 +557,7 @@ class SurfaceGeometry:
             poly=affinity.translate(self.polygon, dx, dy),
             material=self.material,
             density=self._density,
-            concrete=self.concrete
+            concrete=self.concrete,
         )
 
     def rotate(

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -664,13 +664,15 @@ class GenericSectionCalculator(SectionCalculator):
         if self.triangulated_data is not None:
             # Rotate back also triangulated data!
             self._rotate_triangulated_data(theta)
+        # Rotate also curvature!
+        strain_rotated = T @ np.array([[strain[1]], [strain[2]]])
 
         # Create result object
         res = s_res.UltimateBendingMomentResults()
         res.theta = theta
         res.n = N
-        res.chi_y = strain[1]
-        res.chi_z = strain[2]
+        res.chi_y = strain_rotated[0, 0]
+        res.chi_z = strain_rotated[1, 0]
         res.eps_a = strain[0]
         res.m_y = M[0, 0]
         res.m_z = M[1, 0]


### PR DESCRIPTION
This PR solves the bug spot by @MestreCarlos in #163.

Now the following code snippet provided by @MestreCarlos:

```
import math
from pprint import pprint

from shapely import Polygon

from structuralcodes.geometry import SurfaceGeometry
from structuralcodes.materials.concrete import ConcreteEC2_2004
from structuralcodes.materials.reinforcement import ReinforcementEC2_2023
from structuralcodes.sections._generic import GenericSection
from structuralcodes.geometry import add_reinforcement_line

# Materials
concrete = ConcreteEC2_2004(25)
reinforcement = ReinforcementEC2_2023(
    fyk=500, Es=200000, density=7850, ftk=550, epsuk=0.07
)

# Create section
poly = Polygon(((0, 0), (350, 0), (350, 500), (0, 500)))
geo = SurfaceGeometry(poly, concrete)
geo = add_reinforcement_line(
    geo, (50, 450), (300, 450), 20, reinforcement, n=10
)
geo = add_reinforcement_line(geo, (50, 50), (300, 50), 20, reinforcement, n=10)
geo = geo.translate(-175, -250)
sec = GenericSection(geo)

# Draw & print
print('====== SECTION ======')
print('====== Theta = pi/6 ======')
pprint(sec.section_calculator.calculate_bending_strength(theta=math.pi / 6))
```

produces the following expected result:

====== SECTION ======
====== Theta = pi/6 ======
UltimateBendingMomentResults(theta=0.5235987755982988,
                             n=-0.003881820593960583,
                             m_y=-537978185.0265349,
                             m_z=-64913391.04673183,
                             chi_y=-1.4516931240180188e-05,
                             chi_z=-8.381354159325317e-06,
                             eps_a=0.0015959697879269737)