### PR TITLE
feat: Add circular geometries

### DIFF
--- a/docs/api/geometry/geometry_creation.md
+++ b/docs/api/geometry/geometry_creation.md
@@ -70,6 +70,20 @@
 
 ```
 
+## Common geometries
+
+In this section the classes and methods for creating special and common geometries are described. Generally these are simply wrappers of base geometries.
+
+```{eval-rst}
+.. autoclass:: structuralcodes.geometry.CircularGeometry
+
+    .. automethod:: __init__
+
+    .. autoproperty:: radius
+    .. autoproperty:: diameter
+
+```
+
 ## Functions for adding reinforcement
 
 ```{eval-rst}
@@ -79,5 +93,10 @@
 
 ```{eval-rst}
 .. autofunction:: structuralcodes.geometry.add_reinforcement_line
+
+```
+
+```{eval-rst}
+.. autofunction:: structuralcodes.geometry.add_reinforcement_circle
 
 ```

--- a/structuralcodes/geometry/__init__.py
+++ b/structuralcodes/geometry/__init__.py
@@ -1,5 +1,6 @@
 """Main entry point for geometry."""
 
+from ._circular import CircularGeometry
 from ._geometry import (
     CompoundGeometry,
     Geometry,
@@ -25,4 +26,5 @@ __all__ = [
     'UPN',
     'add_reinforcement',
     'add_reinforcement_line',
+    'CircularGeometry',
 ]

--- a/structuralcodes/geometry/__init__.py
+++ b/structuralcodes/geometry/__init__.py
@@ -1,6 +1,6 @@
 """Main entry point for geometry."""
 
-from ._circular import CircularGeometry, CircularRCGeometry
+from ._circular import CircularGeometry
 from ._geometry import (
     CompoundGeometry,
     Geometry,
@@ -32,5 +32,4 @@ __all__ = [
     'add_reinforcement_line',
     'CircularGeometry',
     'add_reinforcement_circle',
-    'CircularRCGeometry',
 ]

--- a/structuralcodes/geometry/__init__.py
+++ b/structuralcodes/geometry/__init__.py
@@ -1,6 +1,6 @@
 """Main entry point for geometry."""
 
-from ._circular import CircularGeometry
+from ._circular import CircularGeometry, CircularRCGeometry
 from ._geometry import (
     CompoundGeometry,
     Geometry,
@@ -32,4 +32,5 @@ __all__ = [
     'add_reinforcement_line',
     'CircularGeometry',
     'add_reinforcement_circle',
+    'CircularRCGeometry',
 ]

--- a/structuralcodes/geometry/__init__.py
+++ b/structuralcodes/geometry/__init__.py
@@ -8,7 +8,11 @@ from ._geometry import (
     SurfaceGeometry,
     create_line_point_angle,
 )
-from ._reinforcement import add_reinforcement, add_reinforcement_line
+from ._reinforcement import (
+    add_reinforcement,
+    add_reinforcement_circle,
+    add_reinforcement_line,
+)
 from ._steel_sections import HE, IPE, IPN, UB, UBP, UC, UPN
 
 __all__ = [
@@ -27,4 +31,5 @@ __all__ = [
     'add_reinforcement',
     'add_reinforcement_line',
     'CircularGeometry',
+    'add_reinforcement_circle',
 ]

--- a/structuralcodes/geometry/_circular.py
+++ b/structuralcodes/geometry/_circular.py
@@ -1,17 +1,9 @@
-"""Classes for circular sections.
+"""Classes for circular geometries.
 
-The class `Circular` represents a circular section with homogenous material.
-The class `CircularRC` represents a reinforced concrete circular section
-with `Concrete` material for the `SurfaceGeometry` and `Reinforcement` material
-for the `PointGeometries`.
-
-These classes are simply wrappers of `GenericSection` class and permits an easy
-input by the user, but all calculations are performed in the under-the-hood
-`GenericSection` class.
-
-In the future this class will contain utility methods for automatically define
-confined concrete according to some confinement models. For now a not
-implemented error is raised if this feature is used.
+The class `CircularGeometry` represents a circular SurfaceGeometry with
+homogenous material.
+This class is simply a wrapper of `SurfaceGeometry` class and permits an easy
+input by the user.
 """
 
 import typing as t

--- a/structuralcodes/geometry/_circular.py
+++ b/structuralcodes/geometry/_circular.py
@@ -13,7 +13,7 @@ from shapely import Polygon
 
 from structuralcodes.core.base import ConstitutiveLaw, Material
 
-from ._geometry import SurfaceGeometry
+from ._geometry import CompoundGeometry, SurfaceGeometry
 
 
 def _create_circle(radius, npoints=20):
@@ -41,7 +41,7 @@ class CircularGeometry(SurfaceGeometry):
         density: t.Optional[float] = None,
         concrete: bool = False,
     ) -> None:
-        """Initialize a CircularSection.
+        """Initialize a CircularGeometry.
 
         Arguments:
             size (float): The size of the geometry. By default this number
@@ -49,8 +49,8 @@ class CircularGeometry(SurfaceGeometry):
                 as the radius `is_radius` should be set as `True`.
             material (Union(Material, ConstitutiveLaw)): A Material or
                 ConsitutiveLaw class applied to the geometry.
-                is_radius (bool): Indicates if size is interpreted as radius
-                    (default = False).
+            is_radius (bool): Indicates if size is interpreted as radius
+                (default = False).
             n_points (int): The number of points used to discretize the
                 circle as a shapely `Polygon` (default = 20).
             density (Optional(float)): When a ConstitutiveLaw is passed as
@@ -70,6 +70,87 @@ class CircularGeometry(SurfaceGeometry):
         self._radius = size if is_radius else size / 2.0
         # Create the shapely polygon
         polygon = _create_circle(radius=self._radius, npoints=n_points)
+        # Pass everything to the base class
+        super().__init__(
+            poly=polygon, material=material, density=density, concrete=concrete
+        )
+
+    @property
+    def radius(self):
+        """Returns the radius of the circle."""
+        return self._radius
+
+    @property
+    def diameter(self):
+        """Return diameter of the circle."""
+        return 2 * self._radius
+
+
+class CircularRCGeometry(CompoundGeometry):
+    """This is a wrapper class for defining a CompoundGeometry made of a
+    surface with circular shape and with a set of bars around the circle.
+    """
+
+    _radius: float
+
+    def __init__(
+        self,
+        size: float,
+        surface_material: t.Union[Material, ConstitutiveLaw],
+        diameter: float,
+        number: int,
+        reinforcement_material: t.Union[Material, ConstitutiveLaw],
+        is_radius: bool = False,
+        n_points: int = 20,
+        surface_density: t.Optional[float] = None,
+        reinforcement_density: t.Optional[float] = None,
+        concrete: bool = False,
+    ) -> None:
+        """Initialize a CircularRCGeometry.
+
+        Arguments:
+            size (float): The size of the geometry. By default this number
+                is assumed as the diameter of the section. To interpret this
+                as the radius `is_radius` should be set as `True`.
+            suface_material (Union(Material, ConstitutiveLaw)): A Material or
+                ConsitutiveLaw class applied to the surface geometry.
+            diameter (float): The diameter of the bars.
+            number (int): The number of bars to distribute.
+            reinforcement_material (Union(Material, ConstitutiveLaw)): A
+                Material or ConsitutiveLaw class applied to the point geometry.
+            is_radius (bool): Indicates if size is interpreted as radius
+                    (default = False).
+            n_points (int): The number of points used to discretize the
+                circle as a shapely `Polygon` (default = 20).
+            surface_density (Optional(float)): When a ConstitutiveLaw is passed
+                as surface_material, the density can be provided by this
+                argument. When surface_material is a Material object the
+                density is taken from the material.
+            reinforcement_density (Optional(float)): When a ConstitutiveLaw is
+                passed as reinforcement_material, the density can be provided
+                by this argument. When reinforcement_material is a Material
+                object the density is taken from the material.
+            concrete (bool): Flag to indicate if the surface geometry is
+                concrete.
+
+        Note:
+            The CircularRCGeometry is simply a wrapper for a CompoundGeometry
+            object.
+        """
+        # Check that size is strictly positive
+        if size <= 0:
+            raise ValueError('Size must be a positive number.')
+        # Manage size as radius or diameter (default)
+        self._radius = size if is_radius else size / 2.0
+        # Create the CircularGeometry
+        geometry = CircularGeometry(
+            size,
+            surface_material,
+            is_radius,
+            n_points,
+            surface_density,
+            concrete,
+        )
         # Pass everything to the base class
         super().__init__(
             poly=polygon, material=material, density=density, concrete=concrete

--- a/structuralcodes/geometry/_circular.py
+++ b/structuralcodes/geometry/_circular.py
@@ -23,7 +23,7 @@ def _create_circle(radius, npoints=20):
     phi = np.linspace(0, 2 * np.pi, npoints + 1)
     x = radius * np.cos(phi)
     y = radius * np.sin(phi)
-    points = [(this_x, this_y) for this_x, this_y in zip(x, y)]
+    points = np.transpose(np.array([x, y]))
     return Polygon(points)
 
 

--- a/structuralcodes/geometry/_circular.py
+++ b/structuralcodes/geometry/_circular.py
@@ -1,0 +1,94 @@
+"""Classes for circular sections.
+
+The class `Circular` represents a circular section with homogenous material.
+The class `CircularRC` represents a reinforced concrete circular section
+with `Concrete` material for the `SurfaceGeometry` and `Reinforcement` material
+for the `PointGeometries`.
+
+These classes are simply wrappers of `GenericSection` class and permits an easy
+input by the user, but all calculations are performed in the under-the-hood
+`GenericSection` class.
+
+In the future this class will contain utility methods for automatically define
+confined concrete according to some confinement models. For now a not
+implemented error is raised if this feature is used.
+"""
+
+import typing as t
+
+import numpy as np
+from shapely import Polygon
+
+from structuralcodes.core.base import ConstitutiveLaw, Material
+
+from ._geometry import SurfaceGeometry
+
+
+def _create_circle(radius, npoints=20):
+    """Create a circle with a given radius."""
+    phi = np.linspace(0, 2 * np.pi, npoints + 1)
+    x = radius * np.cos(phi)
+    y = radius * np.sin(phi)
+    points = [(this_x, this_y) for this_x, this_y in zip(x, y)]
+    return Polygon(points)
+
+
+class CircularGeometry(SurfaceGeometry):
+    """This is a wrapper class for defining a SurfaceGeometry of circular shape
+    with a homogeneous material.
+    """
+
+    _radius: float
+
+    def __init__(
+        self,
+        size: float,
+        material: t.Union[Material, ConstitutiveLaw],
+        is_radius: bool = False,
+        n_points: int = 20,
+        density: t.Optional[float] = None,
+        concrete: bool = False,
+    ) -> None:
+        """Initialize a CircularSection.
+
+        Arguments:
+            size (float): The size of the geometry. By default this number
+                is assumed as the diameter of the section. To interpret this
+                as the radius `is_radius` should be set as `True`.
+            material (Union(Material, ConstitutiveLaw)): A Material or
+                ConsitutiveLaw class applied to the geometry.
+                is_radius (bool): Indicates if size is interpreted as radius
+                    (default = False).
+            n_points (int): The number of points used to discretize the
+                circle as a shapely `Polygon` (default = 20).
+            density (Optional(float)): When a ConstitutiveLaw is passed as
+                material, the density can be provided by this argument. When
+                material is a Material object the density is taken from the
+                material.
+            concrete (bool): Flag to indicate if the geometry is concrete.
+
+        Note:
+            The CircularGeometry is simply a wrapper for a SurfaceGeometry
+            object.
+        """
+        # Check that size is strictly positive
+        if size <= 0:
+            raise ValueError('Size must be a positive number.')
+        # Manage size as radius or diameter (default)
+        self._radius = size if is_radius else size / 2.0
+        # Create the shapely polygon
+        polygon = _create_circle(radius=self._radius, npoints=n_points)
+        # Pass everything to the base class
+        super().__init__(
+            poly=polygon, material=material, density=density, concrete=concrete
+        )
+
+    @property
+    def radius(self):
+        """Returns the radius of the circle."""
+        return self._radius
+
+    @property
+    def diameter(self):
+        """Return diameter of the circle."""
+        return 2 * self._radius

--- a/structuralcodes/geometry/_circular.py
+++ b/structuralcodes/geometry/_circular.py
@@ -7,15 +7,13 @@ input by the user.
 """
 
 import typing as t
-from itertools import chain
 
 import numpy as np
 from shapely import Polygon
 
 from structuralcodes.core.base import ConstitutiveLaw, Material
 
-from ._geometry import CompoundGeometry, SurfaceGeometry
-from ._reinforcement import add_reinforcement_circle
+from ._geometry import SurfaceGeometry
 
 
 def _create_circle(radius, npoints=20):
@@ -70,91 +68,6 @@ class CircularGeometry(SurfaceGeometry):
         # Pass everything to the base class
         super().__init__(
             poly=polygon, material=material, density=density, concrete=concrete
-        )
-
-    @property
-    def radius(self):
-        """Returns the radius of the circle."""
-        return self._radius
-
-    @property
-    def diameter(self):
-        """Return diameter of the circle."""
-        return 2 * self._radius
-
-
-class CircularRCGeometry(CompoundGeometry):
-    """This is a wrapper class for defining a CompoundGeometry made of a
-    surface with circular shape and with a set of bars around the circle.
-    """
-
-    _radius: float
-
-    def __init__(
-        self,
-        size: float,
-        surface_material: t.Union[Material, ConstitutiveLaw],
-        diameter: float,
-        number: int,
-        reinforcement_material: t.Union[Material, ConstitutiveLaw],
-        cover: float,
-        is_radius: bool = False,
-        n_points: int = 20,
-        surface_density: t.Optional[float] = None,
-        concrete: bool = False,
-    ) -> None:
-        """Initialize a CircularRCGeometry.
-
-        Arguments:
-            size (float): The size of the geometry. By default this number
-                is assumed as the diameter of the section. To interpret this
-                as the radius `is_radius` should be set as `True`.
-            suface_material (Union(Material, ConstitutiveLaw)): A Material or
-                ConsitutiveLaw class applied to the surface geometry.
-            diameter (float): The diameter of the bars.
-            number (int): The number of bars to distribute.
-            reinforcement_material (Union(Material, ConstitutiveLaw)): A
-                Material or ConsitutiveLaw class applied to the point geometry.
-            cover (float): The cover of concrete intended as the distance
-                between outer line and barycenter of longitudinal bars.
-            is_radius (bool): Indicates if size is interpreted as radius
-                    (default = False).
-            n_points (int): The number of points used to discretize the
-                circle as a shapely `Polygon` (default = 20).
-            surface_density (Optional(float)): When a ConstitutiveLaw is passed
-                as surface_material, the density can be provided by this
-                argument. When surface_material is a Material object the
-                density is taken from the material.
-            concrete (bool): Flag to indicate if the surface geometry is
-                concrete.
-
-        Note:
-            The CircularRCGeometry is simply a wrapper for a CompoundGeometry
-            object.
-        """
-        # Check that size is strictly positive
-        if size <= 0:
-            raise ValueError('Size must be a positive number.')
-        # Manage size as radius or diameter (default)
-        self._radius = size if is_radius else size / 2.0
-        # Create the CircularGeometry
-        geometry = CircularGeometry(
-            size,
-            surface_material,
-            is_radius,
-            n_points,
-            surface_density,
-            concrete,
-        )
-        # Add the reinforcement
-        r = geometry.radius - cover
-        rc_geometry = add_reinforcement_circle(
-            geometry, (0, 0), r, diameter, reinforcement_material, number
-        )
-
-        # Pass everything to the base class CompoundGeometry
-        super().__init__(
-            list(chain(rc_geometry.geometries, rc_geometry.point_geometries))
         )
 
     @property

--- a/structuralcodes/geometry/_circular.py
+++ b/structuralcodes/geometry/_circular.py
@@ -26,8 +26,8 @@ def _create_circle(radius, npoints=20):
 
 
 class CircularGeometry(SurfaceGeometry):
-    """This is a wrapper class for defining a SurfaceGeometry of circular shape
-    with a homogeneous material.
+    """This is a wrapper class for defining a `SurfaceGeometry` of circular
+    shape with a homogeneous material.
     """
 
     _radius: float

--- a/structuralcodes/geometry/_circular.py
+++ b/structuralcodes/geometry/_circular.py
@@ -36,9 +36,8 @@ class CircularGeometry(SurfaceGeometry):
 
     def __init__(
         self,
-        size: float,
+        diameter: float,
         material: t.Union[Material, ConstitutiveLaw],
-        is_radius: bool = False,
         n_points: int = 20,
         density: t.Optional[float] = None,
         concrete: bool = False,
@@ -46,13 +45,9 @@ class CircularGeometry(SurfaceGeometry):
         """Initialize a CircularGeometry.
 
         Arguments:
-            size (float): The size of the geometry. By default this number
-                is assumed as the diameter of the section. To interpret this
-                as the radius `is_radius` should be set as `True`.
+            diameter (float): The diameter of the geometry.
             material (Union(Material, ConstitutiveLaw)): A Material or
                 ConsitutiveLaw class applied to the geometry.
-            is_radius (bool): Indicates if size is interpreted as radius
-                (default = False).
             n_points (int): The number of points used to discretize the
                 circle as a shapely `Polygon` (default = 20).
             density (Optional(float)): When a ConstitutiveLaw is passed as
@@ -66,10 +61,10 @@ class CircularGeometry(SurfaceGeometry):
             object.
         """
         # Check that size is strictly positive
-        if size <= 0:
-            raise ValueError('Size must be a positive number.')
+        if diameter <= 0:
+            raise ValueError('Diameter must be a positive number.')
         # Manage size as radius or diameter (default)
-        self._radius = size if is_radius else size / 2.0
+        self._radius = diameter / 2.0
         # Create the shapely polygon
         polygon = _create_circle(radius=self._radius, npoints=n_points)
         # Pass everything to the base class

--- a/structuralcodes/geometry/_geometry.py
+++ b/structuralcodes/geometry/_geometry.py
@@ -557,7 +557,7 @@ class SurfaceGeometry:
             poly=affinity.translate(self.polygon, dx, dy),
             material=self.material,
             density=self._density,
-            concrete=self.concrete
+            concrete=self.concrete,
         )
 
     def rotate(

--- a/structuralcodes/geometry/_reinforcement.py
+++ b/structuralcodes/geometry/_reinforcement.py
@@ -139,7 +139,10 @@ def add_reinforcement_circle(
     stop_angle: float = 2 * np.pi,
     group_label: t.Optional[str] = None,
 ) -> CompoundGeometry:
-    """Adds a set of bars distributed in a line.
+    """Adds a set of bars distributed in a circular arch line.
+    By default the whole circle is considered. If one wants to specify a
+    circular arch, the `start_angle` and `stop_angle` attributes need to be
+    specified.
 
     Arguments:
         geo (Union(SurfaceGeometry, CompoundGeometry)): The geometry used as

--- a/structuralcodes/geometry/_reinforcement.py
+++ b/structuralcodes/geometry/_reinforcement.py
@@ -6,11 +6,8 @@ import numpy as np
 from shapely import Point
 
 from structuralcodes.core.base import ConstitutiveLaw, Material
-from structuralcodes.geometry import (
-    CompoundGeometry,
-    PointGeometry,
-    SurfaceGeometry,
-)
+
+from ._geometry import CompoundGeometry, PointGeometry, SurfaceGeometry
 
 
 def add_reinforcement(

--- a/structuralcodes/geometry/_reinforcement.py
+++ b/structuralcodes/geometry/_reinforcement.py
@@ -125,3 +125,127 @@ def add_reinforcement_line(
             group_label=group_label,
         )
     return geo
+
+
+def add_reinforcement_circle(
+    geo: t.Union[SurfaceGeometry, CompoundGeometry],
+    center: t.Tuple[float, float],
+    radius: float,
+    diameter: float,
+    material: t.Union[Material, ConstitutiveLaw],
+    n: int = 0,
+    s: float = 0.0,
+    first: bool = True,
+    last: bool = True,
+    start_angle: float = 0.0,
+    stop_angle: float = 2 * np.pi,
+    group_label: t.Optional[str] = None,
+) -> CompoundGeometry:
+    """Adds a set of bars distributed in a line.
+
+    Arguments:
+        geo (Union(SurfaceGeometry, CompoundGeometry)): The geometry used as
+            input.
+        center (Tuple(float, float)): Coordinates of the center point of
+            the circle line where reinforcement will be added.
+        radius (float): Radius of the circle line where reinforcement will be
+            added.
+        diameter (float): The diameter of the bars.
+        material (Union(Material, ConstitutiveLaw)): A valid material or
+            constitutive law.
+        n (int): The number of bars to be distributed inside the line (default
+            = 0).
+        s (float): The distance between the bars (default = 0).
+        first (bool): Boolean indicating if placing the first bar (default =
+            True).
+        last (bool): Boolean indicating if placing the last bar (default =
+            True).
+        start_angle (float): Start angle (respect to X axis) for defining the
+            arch where to add bars in radians (default = 0)
+        stop_angle (float): Stop angle (respect to X axis) for defining the
+            arch where to add bars in radians (default = 2pi)
+        group_label (Optional(str)): A label for grouping several objects
+            (default is None).
+
+    Note:
+        At least n or s should be greater than zero.
+        Attribues start_angle and stop_angle by default are 0 and 2pi
+        respectively, so that bars will be distributed along the whole circle.
+        If only a portion of the circle must be used (i.e. an arch of
+        circumference), then set start and stop angles correspondingly.
+        stop_angle must always be larger than start_angle.
+
+    Returns:
+        CompoundGeometry: A compound geometry with the original geometry and
+        the reinforcement.
+    """
+    from math import floor
+
+    # Check that difference between stop and start angle is
+    # positive and less than 2pi
+    if stop_angle - start_angle <= 0 or stop_angle - start_angle > 2 * np.pi:
+        raise ValueError(
+            'Stop angle should be larger than start angle and difference \
+            them should be at most 2pi.'
+        )
+    # Calculate length from start_angle to stop_angle
+    length = radius * (stop_angle - start_angle)
+
+    # If the whole circle, than deal with the case that would add an extra bar
+    whole = False
+    add_n = 0
+    if abs(length - 2 * np.pi * radius) < 1e-4:
+        whole = True
+        add_n = 1
+
+    delta_angle = 0
+    if n > 0 and s > 0:
+        # Provided both the number of bars and spacing
+        # 1. Check the is enough space for fitting the bars
+        n += add_n
+        needed_length = (n - 1) * s
+        if needed_length > length:
+            raise ValueError(
+                f'There is not room to fit {n} bars with a spacing of {s} \
+                in {length}'
+            )
+        delta_angle = (length - needed_length) / 2.0 / radius
+    elif n > 0:
+        # Provided the number of bars
+        s = length / (n - 1)
+        n += add_n
+    elif s > 0:
+        # Provided the spacing
+        # 1. Compute the number of bars
+        n = floor(length / s) + 1
+        # 2. Distribute the bars centered in the segment
+        needed_length = (n - 1) * s
+        delta_angle = (length - needed_length) / 2.0 / radius
+        whole = False
+    else:
+        raise ValueError('At least n or s should be provided')
+
+    phi_rebars = np.linspace(
+        start_angle + delta_angle, stop_angle - delta_angle, n
+    )
+    if whole:
+        n -= 1
+        phi_rebars = phi_rebars[:-1]
+
+    x = center[0] + radius * np.cos(phi_rebars)
+    y = center[1] + radius * np.sin(phi_rebars)
+
+    # add the bars
+    for i in range(n):
+        if i == 0 and not first:
+            continue
+        if i == n - 1 and not last:
+            continue
+        geo = add_reinforcement(
+            geo,
+            (x[i], y[i]),
+            diameter,
+            material,
+            group_label=group_label,
+        )
+    return geo

--- a/tests/test_core/test_circular.py
+++ b/tests/test_core/test_circular.py
@@ -1,0 +1,238 @@
+"""Tests for the Geometry."""
+
+import math
+
+import numpy as np
+import pytest
+
+from structuralcodes.geometry import CircularGeometry, add_reinforcement_circle
+from structuralcodes.materials.concrete import ConcreteMC2010
+from structuralcodes.materials.constitutive_laws import Elastic
+from structuralcodes.materials.reinforcement import ReinforcementMC2010
+
+
+# Test create a circular geometry
+@pytest.mark.parametrize(
+    'diameter, n_points',
+    [(100, 20), (200, 20), (300, 20), (300, 30), (400, 40), (500, 24)],
+)
+def test_create_circular_geometry(diameter, n_points):
+    """Test creating a CircularGeometry."""
+    mat = Elastic(300000)
+    circle = CircularGeometry(diameter, mat, n_points)
+
+    assert len(circle.polygon.exterior.coords) == n_points + 2
+
+    assert math.isclose(circle.diameter, diameter)
+    assert math.isclose(circle.radius, diameter / 2.0)
+
+    area = circle.area
+    expected_area = np.pi * diameter**2 / 4.0
+    assert math.isclose(area, expected_area, rel_tol=0.05)
+
+
+# Test wrong input
+@pytest.mark.parametrize('wrong_diameter', [-100, 0])
+def test_create_circular_geometry_exception(wrong_diameter):
+    """Test raising exception when inputing wrong value."""
+    mat = Elastic(300000)
+    with pytest.raises(ValueError):
+        CircularGeometry(wrong_diameter, mat)
+
+
+# Test adding reinforcement in circular pattern
+# Whole circle
+@pytest.mark.parametrize('diameter, cover, n', [(200, 40, 8), (600, 50, 16)])
+def test_reinforced_circular_geometry(diameter, cover, n):
+    """Test adding reinforcemnet to a CircularGeometry."""
+    # Create materials
+    concrete = ConcreteMC2010(40)
+    steel = ReinforcementMC2010(450, 200000, 450, 0.065)
+
+    # create the circular geometry
+    circle = CircularGeometry(diameter, concrete)
+
+    assert circle.concrete
+
+    # add reinforcement in the circular pattern
+    rc = add_reinforcement_circle(
+        geo=circle,
+        center=(0, 0),
+        radius=circle.radius - cover,
+        diameter=16,
+        material=steel,
+        n=n,
+    )
+
+    assert len(rc.point_geometries) == n
+
+
+# Test adding reinforcement in circular pattern
+# circular arch
+@pytest.mark.parametrize('diameter, cover, n', [(200, 40, 8), (600, 50, 16)])
+def test_reinforced_circular_geometry_arch(diameter, cover, n):
+    """Test adding reinforcemnet to a CircularGeometry on circle arches."""
+    # Create materials
+    concrete = ConcreteMC2010(40)
+    steel = ReinforcementMC2010(450, 200000, 450, 0.065)
+
+    # create the circular geometry
+    circle = CircularGeometry(diameter, concrete)
+
+    assert circle.concrete
+
+    # add reinforcement in the circular arch pattern
+    rc = add_reinforcement_circle(
+        geo=circle,
+        center=(0, 0),
+        radius=circle.radius - cover,
+        diameter=16,
+        material=steel,
+        n=int(n / 2) + 1,
+        stop_angle=np.pi,
+    )
+
+    assert len(rc.point_geometries) == int(n / 2) + 1
+
+    # add further reinforcement in a circular arch pattern
+
+    rc = add_reinforcement_circle(
+        geo=rc,
+        center=(0, 0),
+        radius=circle.radius - cover,
+        diameter=16,
+        material=steel,
+        n=int(n / 2) + 1,
+        start_angle=np.pi,
+        stop_angle=np.pi * 2,
+        first=False,
+        last=False,
+    )
+
+    # These two operations should give same result as reinforcement in whole
+    # circumference. Let's check this
+
+    assert len(rc.point_geometries) == n
+
+
+# Test adding reinforcement in circular pattern
+# circular arch
+@pytest.mark.parametrize('diameter, cover, n', [(200, 40, 8), (600, 50, 16)])
+def test_reinforced_circular_geometry_exception(diameter, cover, n):
+    """Test excpetion when adding reinforcemnet to a CircularGeometry."""
+    # Create materials
+    concrete = ConcreteMC2010(40)
+    steel = ReinforcementMC2010(450, 200000, 450, 0.065)
+
+    # create the circular geometry
+    circle = CircularGeometry(diameter, concrete)
+
+    assert circle.concrete
+
+    # add reinforcement in the circular arch pattern
+    with pytest.raises(ValueError):
+        _ = add_reinforcement_circle(
+            geo=circle,
+            center=(0, 0),
+            radius=circle.radius - cover,
+            diameter=16,
+            material=steel,
+            n=int(n / 2) + 1,
+            stop_angle=-np.pi,
+        )
+
+
+# add reinforcement providing spacing
+def test_reinforcement_circular_spacing():
+    """Test adding reinforcement in circular pattern providing spacing."""
+    # Create materials
+    concrete = ConcreteMC2010(40)
+    steel = ReinforcementMC2010(450, 200000, 450, 0.065)
+
+    # create the circular geometry
+    circle = CircularGeometry(300, concrete)
+
+    assert circle.concrete
+
+    # add reinforcement in the circular arch pattern
+    rc = add_reinforcement_circle(
+        geo=circle,
+        center=(0, 0),
+        radius=120,
+        diameter=16,
+        material=steel,
+        s=50,
+        start_angle=0,
+        stop_angle=np.pi,
+    )
+
+    # This should create 8 bars
+    assert len(rc.point_geometries) == 8
+
+
+# add reinforcement providing spacing and number
+def test_reinforcement_circular_spacing_number():
+    """Test adding reinforcement in circular pattern providing spacing and
+    number.
+    """
+    # Create materials
+    concrete = ConcreteMC2010(40)
+    steel = ReinforcementMC2010(450, 200000, 450, 0.065)
+
+    # create the circular geometry
+    circle = CircularGeometry(300, concrete)
+
+    assert circle.concrete
+
+    # add reinforcement in the circular arch pattern
+    rc = add_reinforcement_circle(
+        geo=circle,
+        center=(0, 0),
+        radius=120,
+        diameter=16,
+        material=steel,
+        s=50,
+        n=6,
+        start_angle=0,
+        stop_angle=np.pi,
+    )
+
+    # This should create 6 bars as requested
+    assert len(rc.point_geometries) == 6
+
+    # The first bar should be in position 103.589, 60.574
+    assert math.isclose(
+        rc.point_geometries[0].point.coords[0][0], 103.58960753977033
+    )
+    assert math.isclose(
+        rc.point_geometries[0].point.coords[0][1], 60.57386573231362
+    )
+
+
+# add reinforcement providing spacing and number
+def test_reinforcement_circular_spacing_number_error():
+    """Test raising exception when adding reinforcement in circular pattern
+    providing spacing and number.
+    """
+    # Create materials
+    concrete = ConcreteMC2010(40)
+    steel = ReinforcementMC2010(450, 200000, 450, 0.065)
+
+    # create the circular geometry
+    circle = CircularGeometry(300, concrete)
+
+    assert circle.concrete
+
+    # add reinforcement in the circular arch pattern
+    with pytest.raises(ValueError):
+        _ = add_reinforcement_circle(
+            geo=circle,
+            center=(0, 0),
+            radius=120,
+            diameter=16,
+            material=steel,
+            s=50,
+            n=10,
+            start_angle=0,
+            stop_angle=np.pi,
+        )


### PR DESCRIPTION
This PR includes a wrapper utility for creating circular geometries.

There is a `CircularGeometry` that represents a `SurfaceGeometry` with a circular shape. It can be created with:
```
circle = CircularGeometry(300, material)
```
Where 300 is the size of the section (by default it is the diameter, unless the argument `is_radius` is set to `True`) and material is a valid `Material` or `ConstitutiveLaw` object.

The resulting geometry can be further worked editing it with additions, subtractions, transformations. When the geometry is set, that can be assigned to a `GenericSection` to perform the computations.

Then a utility method inside `_reinforcement` named `add_reinforcement_circle` has been included permitting by default the distribution of `n` given bars (or given the spacing `s`) within the whole circumference. Passing `start_angle` and `stop_angle` the bars can be distributed in a circular arch instead that on the whole circumference. 

Finally a derived class of `CompoundGeometry` named `CircularRCGeometry` has been developed permitting with a very simple syntax to add the bars around the whole perimeter.

```
geo_rc = CircularRCGeometry(
    size=300,
    surface_material=material,
    diameter=12,
    number=8,
    cover=40,
    reinforcement_material=material,
    n_points=50,
)
geo_rc
```
which produces the following:
![image](https://github.com/user-attachments/assets/f6bbb578-9aba-4d5c-89d4-185cea84624f)

The alternative would have been creating methods instead of classes that return a Surface or Compound Geometry.

TODO:
- [x] Add tests when agreeing on this design