### PR TITLE
feat: add origin kwarg to wrapper geom classes

### DIFF
--- a/structuralcodes/geometry/_circular.py
+++ b/structuralcodes/geometry/_circular.py
@@ -9,6 +9,7 @@ input by the user.
 import typing as t
 
 import numpy as np
+from numpy.typing import ArrayLike
 from shapely import Polygon
 
 from structuralcodes.core.base import ConstitutiveLaw, Material
@@ -16,11 +17,12 @@ from structuralcodes.core.base import ConstitutiveLaw, Material
 from ._geometry import SurfaceGeometry
 
 
-def _create_circle(radius, npoints=20):
+def _create_circle(radius, npoints=20, origin: t.Optional[ArrayLike] = None):
     """Create a circle with a given radius."""
+    origin = origin if origin is not None else (0.0, 0.0)
     phi = np.linspace(0, 2 * np.pi, npoints + 1)
-    x = radius * np.cos(phi)
-    y = radius * np.sin(phi)
+    x = radius * np.cos(phi) + origin[0]
+    y = radius * np.sin(phi) + origin[1]
     points = np.transpose(np.array([x, y]))
     return Polygon(points)
 
@@ -39,6 +41,7 @@ class CircularGeometry(SurfaceGeometry):
         n_points: int = 20,
         density: t.Optional[float] = None,
         concrete: bool = False,
+        origin: t.Optional[ArrayLike] = None,
     ) -> None:
         """Initialize a CircularGeometry.
 
@@ -53,6 +56,8 @@ class CircularGeometry(SurfaceGeometry):
                 material is a Material object the density is taken from the
                 material.
             concrete (bool): Flag to indicate if the geometry is concrete.
+            origin (Optional(ArrayLike)): The center point of the circle.
+                (0.0, 0.0) is used as default.
 
         Note:
             The CircularGeometry is simply a wrapper for a SurfaceGeometry
@@ -63,8 +68,14 @@ class CircularGeometry(SurfaceGeometry):
             raise ValueError('Diameter must be a positive number.')
         # Manage size as radius or diameter (default)
         self._radius = diameter / 2.0
+        # Parse origin
+        if origin is not None and len(origin) != 2:
+            raise ValueError('origin must be an ArrayLike with len == 2')
+        origin = origin if origin is not None else (0.0, 0.0)
         # Create the shapely polygon
-        polygon = _create_circle(radius=self._radius, npoints=n_points)
+        polygon = _create_circle(
+            radius=self._radius, npoints=n_points, origin=origin
+        )
         # Pass everything to the base class
         super().__init__(
             poly=polygon, material=material, density=density, concrete=concrete

--- a/structuralcodes/geometry/_rectangular.py
+++ b/structuralcodes/geometry/_rectangular.py
@@ -8,6 +8,7 @@ input by the user.
 
 import typing as t
 
+from numpy.typing import ArrayLike
 from shapely import Polygon
 
 from structuralcodes.core.base import ConstitutiveLaw, Material
@@ -30,6 +31,7 @@ class RectangularGeometry(SurfaceGeometry):
         material: t.Union[Material, ConstitutiveLaw],
         density: t.Optional[float] = None,
         concrete: bool = False,
+        origin: t.Optional[ArrayLike] = None,
     ) -> None:
         """Initialize a RectangularGeometry.
 
@@ -44,6 +46,8 @@ class RectangularGeometry(SurfaceGeometry):
                 material.
             concrete (bool): Flag to indicate if the geometry is concrete. When
                 passing a Material as material, this is automatically inferred.
+            origin (Optional(ArrayLike)): The center point of the rectangle.
+                (0.0, 0.0) is used as default.
 
         Note:
             The RectangularGeometry is simply a wrapper for a SurfaceGeometry
@@ -58,13 +62,18 @@ class RectangularGeometry(SurfaceGeometry):
         self._width = width
         self._height = height
 
+        # Parse origin
+        if origin is not None and len(origin) != 2:
+            raise ValueError('origin must be an ArrayLike with len == 2')
+        origin = origin if origin is not None else (0.0, 0.0)
+
         # Create the shapely polygon
         polygon = Polygon(
             (
-                (-width / 2, -height / 2),
-                (width / 2, -height / 2),
-                (width / 2, height / 2),
-                (-width / 2, height / 2),
+                (-width / 2 + origin[0], -height / 2 + origin[1]),
+                (width / 2 + origin[0], -height / 2 + origin[1]),
+                (width / 2 + origin[0], height / 2 + origin[1]),
+                (-width / 2 + origin[0], height / 2 + origin[1]),
             )
         )
         # Pass everything to the base class

--- a/tests/test_geometry/test_circular.py
+++ b/tests/test_geometry/test_circular.py
@@ -40,6 +40,37 @@ def test_create_circular_geometry_exception(wrong_diameter):
         CircularGeometry(wrong_diameter, mat)
 
 
+# Test providing origin
+@pytest.mark.parametrize(
+    'origin',
+    [(0, 0), (30, 600), (1.0,)],
+)
+def test_circle_with_origin(origin):
+    """Test creating a circle with an origin."""
+    # Arrange
+    mat = Elastic(300000)
+    diameter = 100
+
+    # Act and assert
+    if origin is not None and len(origin) == 2:
+        geom = CircularGeometry(diameter=diameter, material=mat, origin=origin)
+        assert np.allclose(
+            (geom.polygon.centroid.xy[0][0], geom.polygon.centroid.xy[1][0]),
+            origin,
+        )
+    elif origin is None:
+        geom = CircularGeometry(diameter=diameter, material=mat, origin=origin)
+        assert np.allclose(
+            (geom.polygon.centroid.xy[0][0], geom.polygon.centroid.xy[1][0]),
+            (0, 0),
+        )
+    else:
+        with pytest.raises(ValueError):
+            geom = CircularGeometry(
+                diameter=diameter, material=mat, origin=origin
+            )
+
+
 # Test adding reinforcement in circular pattern
 # Whole circle
 @pytest.mark.parametrize('diameter, cover, n', [(200, 40, 8), (600, 50, 16)])

--- a/tests/test_geometry/test_circular.py
+++ b/tests/test_geometry/test_circular.py
@@ -43,7 +43,7 @@ def test_create_circular_geometry_exception(wrong_diameter):
 # Test providing origin
 @pytest.mark.parametrize(
     'origin',
-    [(0, 0), (30, 600), (1.0,)],
+    [(0, 0), (30, 600), (1.0,), None],
 )
 def test_circle_with_origin(origin):
     """Test creating a circle with an origin."""

--- a/tests/test_geometry/test_rectangular.py
+++ b/tests/test_geometry/test_rectangular.py
@@ -55,7 +55,7 @@ def test_create_rectangular_geometry_exception(wrong_width, wrong_height):
 # Test providing origin
 @pytest.mark.parametrize(
     'origin',
-    [(0, 0), (30, 600), (1.0,)],
+    [(0, 0), (30, 600), (1.0,), None],
 )
 def test_rectangle_with_origin(origin):
     """Test creating a rectangle with an origin."""

--- a/tests/test_geometry/test_rectangular.py
+++ b/tests/test_geometry/test_rectangular.py
@@ -2,6 +2,7 @@
 
 import math
 
+import numpy as np
 import pytest
 
 from structuralcodes.geometry import (
@@ -49,6 +50,42 @@ def test_create_rectangular_geometry_exception(wrong_width, wrong_height):
     mat = Elastic(30000)
     with pytest.raises(ValueError):
         RectangularGeometry(wrong_width, wrong_height, mat)
+
+
+# Test providing origin
+@pytest.mark.parametrize(
+    'origin',
+    [(0, 0), (30, 600), (1.0,)],
+)
+def test_rectangle_with_origin(origin):
+    """Test creating a rectangle with an origin."""
+    # Arrange
+    mat = Elastic(30000)
+    height = 600
+    width = 200
+
+    # Act and assert
+    if origin is not None and len(origin) == 2:
+        geom = RectangularGeometry(
+            width=width, height=height, material=mat, origin=origin
+        )
+        assert np.allclose(
+            (geom.polygon.centroid.xy[0][0], geom.polygon.centroid.xy[1][0]),
+            origin,
+        )
+    elif origin is None:
+        geom = RectangularGeometry(
+            width=width, height=height, material=mat, origin=origin
+        )
+        assert np.allclose(
+            (geom.polygon.centroid.xy[0][0], geom.polygon.centroid.xy[1][0]),
+            (0, 0),
+        )
+    else:
+        with pytest.raises(ValueError):
+            geom = RectangularGeometry(
+                width=width, height=height, material=mat, origin=origin
+            )
 
 
 # Test adding reinforcement in circular pattern


### PR DESCRIPTION
I have added a kwarg to both the `CircularGeometry` and the `RectangularGeometry` to easily set the origin of the geometry to a point other than `(0.0, 0.0)`.