### PR TITLE
fix: get_stress in BilinearCompression

### DIFF
--- a/structuralcodes/materials/constitutive_laws/_bilinearcompression.py
+++ b/structuralcodes/materials/constitutive_laws/_bilinearcompression.py
@@ -51,14 +51,10 @@ class BilinearCompression(ConstitutiveLaw):
         # Compute stress
         # If it is a scalar
         if np.isscalar(eps):
-            sig = self._E * eps
-            if eps > 0:
-                return 0
-            if eps < self._eps_cu:
-                return 0
-            if sig < self._fc:
-                return self._fc
-            return sig
+            if eps > 0 or eps < self._eps_cu:
+               return 0
+            return max(self._E * eps, self._fc)
+        
         # If it is an array
         sig = self._E * eps
         sig[sig < self._fc] = self._fc
@@ -73,13 +69,14 @@ class BilinearCompression(ConstitutiveLaw):
         eps = eps if np.isscalar(eps) else np.atleast_1d(eps)
         # If it is a scalar
         if np.isscalar(eps):
-            tangent = 0
-            if self._fc / self._E <= eps <= 0:
-                tangent = self._E
-            return tangent
+            if self._eps_c < eps <= 0:
+                return self._E
+            return 0
+
         # If it is an array
         tangent = np.ones_like(eps) * self._E
-        tangent[eps < self._eps_c] = 0.0
+        tangent[eps >= 0] = 0
+        tangent[eps < self._eps_c] = 0
 
         return tangent
 

--- a/structuralcodes/materials/constitutive_laws/_bilinearcompression.py
+++ b/structuralcodes/materials/constitutive_laws/_bilinearcompression.py
@@ -51,9 +51,13 @@ class BilinearCompression(ConstitutiveLaw):
         # Compute stress
         # If it is a scalar
         if np.isscalar(eps):
-            sig = 0
-            if self._fc / self._E <= eps <= 0:
-                sig = self._E * eps
+            sig = self._E * eps
+            if eps > 0:
+                return 0
+            if eps < self._eps_cu:
+                return 0
+            if sig < self._fc:
+                return self._fc
             return sig
         # If it is an array
         sig = self._E * eps

--- a/tests/test_materials/test_constitutive_laws.py
+++ b/tests/test_materials/test_constitutive_laws.py
@@ -489,25 +489,31 @@ def test_bilinearcompression(fc, eps_c, eps_cu):
     """Test BilinearCompression material."""
     law = BilinearCompression(fc=fc, eps_c=eps_c, eps_cu=eps_cu)
 
-    eps = np.linspace(0, eps_cu, 20)
+    eps = np.linspace(-2*eps_cu, eps_c, 20)
 
     # compute expected
     E = fc / eps_c
     sig_expected = E * eps
-    sig_expected[sig_expected > fc] = fc
-    tan_expected = np.zeros_like(sig_expected)
-    tan_expected[sig_expected < fc] = E
-    sig_expected *= -1
+    sig_expected[sig_expected < -fc] = -fc
+    sig_expected[eps > 0] = 0
+    sig_expected[eps < -eps_cu] = 0
+    tan_expected = np.ones_like(eps) * E
+    tan_expected[eps >= 0] = 0
+    tan_expected[eps < -eps_c] = 0
 
     # compute from BilinearCompression
-    sig_computed_array = law.get_stress(-eps)
-    sig_computed_scalar = np.array([law.get_stress(-eps_scalar) for eps_scalar in eps])
-    tan_computed = law.get_tangent(-eps)
+    sig_computed_array = law.get_stress(eps)
+    sig_computed_scalar = np.array([law.get_stress(eps_scalar) for eps_scalar in eps])
+    tan_computed_array = law.get_tangent(eps)
+    tan_computed_scalar = np.array([law.get_tangent(eps_scalar) for eps_scalar in eps])
+
 
     # Compare the two
     assert_allclose(sig_computed_array, sig_expected)
     assert_allclose(sig_computed_scalar, sig_expected)
-    assert_allclose(tan_computed, tan_expected)
+    assert_allclose(tan_computed_array, tan_expected)
+    assert_allclose(tan_computed_scalar, tan_expected)
+
 
     # Test getting ultimate strain
     eps_min, eps_max = law.get_ultimate_strain()

--- a/tests/test_materials/test_constitutive_laws.py
+++ b/tests/test_materials/test_constitutive_laws.py
@@ -500,11 +500,13 @@ def test_bilinearcompression(fc, eps_c, eps_cu):
     sig_expected *= -1
 
     # compute from BilinearCompression
-    sig_computed = law.get_stress(-eps)
+    sig_computed_array = law.get_stress(-eps)
+    sig_computed_scalar = np.array([law.get_stress(-eps_scalar) for eps_scalar in eps])
     tan_computed = law.get_tangent(-eps)
 
     # Compare the two
-    assert_allclose(sig_computed, sig_expected)
+    assert_allclose(sig_computed_array, sig_expected)
+    assert_allclose(sig_computed_scalar, sig_expected)
     assert_allclose(tan_computed, tan_expected)
 
     # Test getting ultimate strain


### PR DESCRIPTION
Fixes #215 

Updated the code, so the approach for arrays and scalars are the same. and added scalar to the test