### PR TITLE
fix: bugfix mn domain

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,20 @@
 {
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    
-   // Config for ruff extension in VSCode
-   "[python]": {
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  // Config for ruff extension in VSCode
+  "[python]": {
     "editor.formatOnSave": true, // Enable auto format on save
     "editor.codeActionsOnSave": {
       "source.fixAll": "explicit",
       "source.organizeImports": "explicit" // This lets ruff reorganize the imports
     },
     "editor.defaultFormatter": "charliermarsh.ruff"
-    },
-    "notebook.formatOnSave.enabled": true,
-    "notebook.codeActionsOnSave": {
-    "notebook.source.organizeImports": "explicit",
-    // "source.fixAll": "explicit",
-    }
+  },
+  "notebook.formatOnSave.enabled": true,
+  "notebook.codeActionsOnSave": {
+    "notebook.source.organizeImports": "explicit"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,13 +5,18 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     
-    // Config for ruff extension in VSCode
-    "[python]": {
-        "editor.formatOnSave": true, // Enable auto format on save
-        "editor.codeActionsOnSave": {
-          "source.fixAll": "explicit",
-          "source.organizeImports": "explicit" // This lets ruff reorganize the imports
-        },
-        "editor.defaultFormatter": "charliermarsh.ruff"
+   // Config for ruff extension in VSCode
+   "[python]": {
+    "editor.formatOnSave": true, // Enable auto format on save
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit" // This lets ruff reorganize the imports
+    },
+    "editor.defaultFormatter": "charliermarsh.ruff"
+    },
+    "notebook.formatOnSave.enabled": true,
+    "notebook.codeActionsOnSave": {
+    "notebook.source.organizeImports": "explicit",
+    // "source.fixAll": "explicit",
     }
 }


### PR DESCRIPTION
Solved a bug for which the yield strain is used in computing the balanced failure strain plane if the section is not of reinforced concrete.