### PR TITLE
feat: use only material objects in geometry objects

### DIFF
--- a/structuralcodes/geometry/_circular.py
+++ b/structuralcodes/geometry/_circular.py
@@ -12,7 +12,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 from shapely import Polygon
 
-from structuralcodes.core.base import ConstitutiveLaw, Material
+from structuralcodes.core.base import Material
 
 from ._geometry import SurfaceGeometry
 
@@ -37,9 +37,8 @@ class CircularGeometry(SurfaceGeometry):
     def __init__(
         self,
         diameter: float,
-        material: t.Union[Material, ConstitutiveLaw],
+        material: Material,
         n_points: int = 20,
-        density: t.Optional[float] = None,
         concrete: bool = False,
         origin: t.Optional[ArrayLike] = None,
         name: t.Optional[str] = None,
@@ -49,14 +48,9 @@ class CircularGeometry(SurfaceGeometry):
 
         Arguments:
             diameter (float): The diameter of the geometry.
-            material (Union(Material, ConstitutiveLaw)): A Material or
-                ConsitutiveLaw class applied to the geometry.
+            material (Material): A Material class applied to the geometry.
             n_points (int): The number of points used to discretize the
                 circle as a shapely `Polygon` (default = 20).
-            density (Optional(float)): When a ConstitutiveLaw is passed as
-                material, the density can be provided by this argument. When
-                material is a Material object the density is taken from the
-                material.
             concrete (bool): Flag to indicate if the geometry is concrete.
             origin (Optional(ArrayLike)): The center point of the circle.
                 (0.0, 0.0) is used as default.
@@ -84,7 +78,6 @@ class CircularGeometry(SurfaceGeometry):
         super().__init__(
             poly=polygon,
             material=material,
-            density=density,
             concrete=concrete,
             name=name,
             group_label=group_label,

--- a/structuralcodes/geometry/_geometry.py
+++ b/structuralcodes/geometry/_geometry.py
@@ -251,10 +251,7 @@ class PointGeometry(Geometry):
         else:
             # new_material not provided, assume elastic material with same
             # elastic modulus
-            new_material = ElasticMaterial(
-                E=geo.material.constitutive_law.get_tangent(eps=0),
-                density=geo.material.density,
-            )
+            new_material = ElasticMaterial.from_material(geo.material)
 
         return PointGeometry(
             point=geo._point,
@@ -588,10 +585,7 @@ class SurfaceGeometry(Geometry):
         else:
             # new_material not provided, assume elastic material with same
             # elastic modulus
-            new_material = ElasticMaterial(
-                E=geo.material.constitutive_law.get_tangent(eps=0),
-                density=geo.material.density,
-            )
+            new_material = ElasticMaterial.from_material(geo.material)
 
         return SurfaceGeometry(poly=geo.polygon, material=new_material)
 

--- a/structuralcodes/geometry/_rectangular.py
+++ b/structuralcodes/geometry/_rectangular.py
@@ -11,7 +11,7 @@ import typing as t
 from numpy.typing import ArrayLike
 from shapely import Polygon
 
-from structuralcodes.core.base import ConstitutiveLaw, Material
+from structuralcodes.core.base import Material
 
 from ._geometry import SurfaceGeometry
 
@@ -28,8 +28,7 @@ class RectangularGeometry(SurfaceGeometry):
         self,
         width: float,
         height: float,
-        material: t.Union[Material, ConstitutiveLaw],
-        density: t.Optional[float] = None,
+        material: Material,
         concrete: bool = False,
         origin: t.Optional[ArrayLike] = None,
         name: t.Optional[str] = None,
@@ -40,12 +39,7 @@ class RectangularGeometry(SurfaceGeometry):
         Arguments:
             width (float): The width of the geometry.
             height (float): The height of the geometry.
-            material (Union(Material, ConstitutiveLaw)): A Material or
-                ConsitutiveLaw class applied to the geometry.
-            density (Optional(float)): When a ConstitutiveLaw is passed as
-                material, the density can be provided by this argument. When
-                material is a Material object the density is taken from the
-                material.
+            material (Material): A Material class applied to the geometry.
             concrete (bool): Flag to indicate if the geometry is concrete. When
                 passing a Material as material, this is automatically inferred.
             origin (Optional(ArrayLike)): The center point of the rectangle.
@@ -84,7 +78,6 @@ class RectangularGeometry(SurfaceGeometry):
         super().__init__(
             poly=polygon,
             material=material,
-            density=density,
             concrete=concrete,
             name=name,
             group_label=group_label,

--- a/structuralcodes/geometry/_reinforcement.py
+++ b/structuralcodes/geometry/_reinforcement.py
@@ -6,7 +6,7 @@ import typing as t
 import numpy as np
 from shapely import Point
 
-from structuralcodes.core.base import ConstitutiveLaw, Material
+from structuralcodes.core.base import Material
 
 from ._geometry import CompoundGeometry, PointGeometry, SurfaceGeometry
 
@@ -15,7 +15,7 @@ def add_reinforcement(
     geo: t.Union[SurfaceGeometry, CompoundGeometry],
     coords: t.Tuple[float, float],
     diameter: float,
-    material: t.Union[Material, ConstitutiveLaw],
+    material: Material,
     group_label: t.Optional[str] = None,
 ) -> CompoundGeometry:
     """Add a single bar given coordinate.
@@ -25,8 +25,7 @@ def add_reinforcement(
             reinforcement.
         coords (Tuple(float, float)): A tuple with cordinates of bar.
         diameter (float): The diameter of the reinforcement.
-        material (Union(Material, ConstitutiveLaw)): A material or a
-            constitutive law for the behavior of the reinforcement.
+        material (Material): A material for the reinforcement.
         group_label (Optional(str)): A label for grouping several objects
             (default is None).
 
@@ -45,7 +44,7 @@ def add_reinforcement_line(
     coords_i: t.Tuple[float, float],
     coords_j: t.Tuple[float, float],
     diameter: float,
-    material: t.Union[Material, ConstitutiveLaw],
+    material: Material,
     n: int = 0,
     s: float = 0.0,
     first: bool = True,
@@ -60,9 +59,8 @@ def add_reinforcement_line(
         coords_i (Tuple(float, float)): Coordinates of the initial point of
             line.
         coords_j (Tuple(float, float)): Coordinates of the final point of line.
-        diamter (float): The diameter of the bars.
-        material (Union(Material, ConstitutiveLaw)): A valid material or
-            constitutive law.
+        diameter (float): The diameter of the bars.
+        material (Material): A material for the reinforcement.
         n (int): The number of bars to be distributed inside the line (default
             = 0).
         s (float): The distance between the bars (default = 0).
@@ -130,7 +128,7 @@ def add_reinforcement_circle(
     center: t.Tuple[float, float],
     radius: float,
     diameter: float,
-    material: t.Union[Material, ConstitutiveLaw],
+    material: Material,
     n: int = 0,
     s: float = 0.0,
     first: bool = True,
@@ -152,8 +150,7 @@ def add_reinforcement_circle(
         radius (float): Radius of the circle line where reinforcement will be
             added.
         diameter (float): The diameter of the bars.
-        material (Union(Material, ConstitutiveLaw)): A valid material or
-            constitutive law.
+        material (Material): A material for the reinforcement.
         n (int): The number of bars to be distributed inside the line (default
             = 0).
         s (float): The distance between the bars (default = 0).

--- a/structuralcodes/materials/__init__.py
+++ b/structuralcodes/materials/__init__.py
@@ -1,9 +1,10 @@
 """Main entry point for materials."""
 
-from . import concrete, constitutive_laws, reinforcement
+from . import basic, concrete, constitutive_laws, reinforcement
 
 __all__ = [
     'concrete',
     'constitutive_laws',
     'reinforcement',
+    'basic',
 ]

--- a/structuralcodes/materials/basic/__init__.py
+++ b/structuralcodes/materials/basic/__init__.py
@@ -1,0 +1,11 @@
+"""A collection of basic material classes."""
+
+from ._elastic import ElasticMaterial
+from ._elasticplastic import ElasticPlasticMaterial
+from ._generic import GenericMaterial
+
+__all__ = [
+    'ElasticMaterial',
+    'ElasticPlasticMaterial',
+    'GenericMaterial',
+]

--- a/structuralcodes/materials/basic/_elastic.py
+++ b/structuralcodes/materials/basic/_elastic.py
@@ -36,3 +36,17 @@ class ElasticMaterial(Material):
     def __elastic__(self) -> dict:
         """Returns kwargs for creating an elastic constitutive law."""
         return {'E': self.E}
+
+    @classmethod
+    def from_material(cls, other_material: Material):
+        """Create an elastic material based on another material."""
+        # Create name of elastic material
+        name = other_material.name
+        if name is not None:
+            name += '_elastic'
+
+        return cls(
+            E=other_material.constitutive_law.get_tangent(eps=0),
+            density=other_material.density,
+            name=name,
+        )

--- a/structuralcodes/materials/basic/_elastic.py
+++ b/structuralcodes/materials/basic/_elastic.py
@@ -1,0 +1,38 @@
+"""A material class with elastic properties."""
+
+import typing as t
+
+from ...core.base import Material
+from ..constitutive_laws import create_constitutive_law
+
+
+class ElasticMaterial(Material):
+    """A material class with elastic properties."""
+
+    _E: float
+
+    def __init__(
+        self,
+        E: float,
+        density: float,
+        name: t.Optional[str] = None,
+    ):
+        """Initialize a material with an elastic plastic constitutive law.
+
+        Arguments:
+            E (float): The Young's modulus.
+            density (float): The density.
+            name (str, optional): The name of the material, default value None.
+        """
+        super().__init__(density=density, name=name)
+        self._E = E
+        self._constitutive_law = create_constitutive_law('elastic', self)
+
+    @property
+    def E(self) -> float:
+        """Returns the Young's modulus."""
+        return self._E
+
+    def __elastic__(self) -> dict:
+        """Returns kwargs for creating an elastic constitutive law."""
+        return {'E': self.E}

--- a/structuralcodes/materials/basic/_elasticplastic.py
+++ b/structuralcodes/materials/basic/_elasticplastic.py
@@ -1,0 +1,75 @@
+"""A material class with elastic plastic properties."""
+
+import typing as t
+
+from ...core.base import Material
+from ..constitutive_laws import create_constitutive_law
+
+
+class ElasticPlasticMaterial(Material):
+    """A material class with elastic plastic properties."""
+
+    _E: float
+    _fy: float
+    _Eh: float
+    _eps_su: float
+
+    def __init__(
+        self,
+        E: float,
+        fy: float,
+        density: float,
+        Eh: float = 0,
+        eps_su: t.Optional[float] = None,
+        name: t.Optional[str] = None,
+    ):
+        """Initialize a material with an elastic plastic constitutive law.
+
+        Arguments:
+            E (float): The Young's modulus.
+            fy (float): The yield stress.
+            density (float): The density.
+            Eh (float, optional): The hardening modulus, default value 0.
+            eps_su (float, optional): The ultimate strain, default value None.
+            name (str, optional): The name of the material, default value None.
+        """
+        super().__init__(density=density, name=name)
+        self._E = E
+        self._fy = fy
+        self._Eh = Eh
+        self._eps_su = eps_su
+
+        self._constitutive_law = create_constitutive_law(
+            'elasticplastic', self
+        )
+
+    @property
+    def E(self) -> float:
+        """Returns the Young's modulus."""
+        return self._E
+
+    @property
+    def fy(self) -> float:
+        """Returns the yield stress."""
+        return self._fy
+
+    @property
+    def Eh(self) -> float:
+        """Returns the hardening modulus."""
+        return self._Eh
+
+    @property
+    def eps_su(self) -> float:
+        """Returns the ultimate strain."""
+        return self._eps_su
+
+    def __elasticplastic__(self) -> dict:
+        """Returns kwargs for ElasticPlastic constitutive law with strain
+        hardening.
+        """
+        return {
+            'E': self.E,
+            'fy': self.fy,
+            'Eh': self.Eh,
+            'eps_su': self.eps_su,
+        }

--- a/structuralcodes/materials/basic/_generic.py
+++ b/structuralcodes/materials/basic/_generic.py
@@ -1,0 +1,26 @@
+"""A generic material that could hold any type of constitutive law."""
+
+import typing as t
+
+from ...core.base import ConstitutiveLaw, Material
+
+
+class GenericMaterial(Material):
+    """A material class that accepts any constitutive law."""
+
+    def __init__(
+        self,
+        density: float,
+        constitutive_law: ConstitutiveLaw,
+        name: t.Optional[str] = None,
+    ):
+        """Initialize a material with a constitutive law.
+
+        Arguments:
+            density (float): The density.
+            constitutive_law (ConstitutiveLaw): The constitutive law of the
+                material.
+            name (str, optional): The name of the material, default value None.
+        """
+        super().__init__(density=density, name=name)
+        self._constitutive_law = constitutive_law

--- a/structuralcodes/sections/_rc_utils.py
+++ b/structuralcodes/sections/_rc_utils.py
@@ -64,6 +64,7 @@ def calculate_elastic_cracked_properties(
         elastic_concrete = GenericMaterial(
             density=density,
             constitutive_law=elastic_concrete_law,
+            name='elastic concrete',
         )
         geo._material = elastic_concrete
 

--- a/structuralcodes/sections/section_integrators/_fiber_integrator.py
+++ b/structuralcodes/sections/section_integrators/_fiber_integrator.py
@@ -88,7 +88,7 @@ class FiberIntegrator(SectionIntegrator):
             max_area = g.area * mesh_size
             # triangulate the geometry getting back the mesh
             mesh = triangle.triangulate(tri, f'pq{30:.1f}Aa{max_area}o1')
-            mat = g.material
+            constitutive_law = g.material.constitutive_law
             # Get x and y coordinates (centroid) and area for each fiber
             x = []
             y = []
@@ -128,7 +128,7 @@ class FiberIntegrator(SectionIntegrator):
 
             # return back the triangulation data
             triangulated_data.append(
-                (np.array(x), np.array(y), np.array(area), mat)
+                (np.array(x), np.array(y), np.array(area), constitutive_law)
             )
         # For the reinforcement
         # Tentative proposal for managing reinforcement (PointGeometry)
@@ -139,19 +139,27 @@ class FiberIntegrator(SectionIntegrator):
             x = x[0]
             y = y[0]
             area = pg.area
-            mat = pg.material
-            if reinf_data.get(mat) is None:
-                reinf_data[mat] = [
+            constitutive_law = pg.material.constitutive_law
+            if reinf_data.get(constitutive_law) is None:
+                reinf_data[constitutive_law] = [
                     np.array(x),
                     np.array(y),
                     np.array(area),
                 ]
             else:
-                reinf_data[mat][0] = np.hstack((reinf_data[mat][0], x))
-                reinf_data[mat][1] = np.hstack((reinf_data[mat][1], y))
-                reinf_data[mat][2] = np.hstack((reinf_data[mat][2], area))
-        for mat, value in reinf_data.items():
-            triangulated_data.append((value[0], value[1], value[2], mat))
+                reinf_data[constitutive_law][0] = np.hstack(
+                    (reinf_data[constitutive_law][0], x)
+                )
+                reinf_data[constitutive_law][1] = np.hstack(
+                    (reinf_data[constitutive_law][1], y)
+                )
+                reinf_data[constitutive_law][2] = np.hstack(
+                    (reinf_data[constitutive_law][2], area)
+                )
+        for constitutive_law, value in reinf_data.items():
+            triangulated_data.append(
+                (value[0], value[1], value[2], constitutive_law)
+            )
 
         return triangulated_data
 

--- a/structuralcodes/sections/section_integrators/_marin_integrator.py
+++ b/structuralcodes/sections/section_integrators/_marin_integrator.py
@@ -71,29 +71,32 @@ class MarinIntegrator(SectionIntegrator):
     ) -> t.Tuple[t.List[t.Tuple], t.List[t.Tuple]]:
         """Get Marin coefficients."""
         if integrate == 'stress':
-            if hasattr(geo.material, '__marin__'):
-                strains, coeffs = geo.material.__marin__(strain=strain)
+            if hasattr(geo.material.constitutive_law, '__marin__'):
+                strains, coeffs = geo.material.constitutive_law.__marin__(
+                    strain=strain
+                )
             else:
                 raise AttributeError(
-                    f'The material object {geo.material} of geometry {geo} \
-                    does not have implement the __marin__ function. \
-                    Please implement the function or use another integrator,\
-                     like '
-                    'Fibre'
-                    ''
+                    'The constitutive law object '
+                    f'{geo.material.constitutive_law} of geometry {geo} does '
+                    'not have implement the __marin__ function. Please '
+                    'implement the function or use another integrator, like '
+                    'Fiber.'
                 )
         elif integrate == 'modulus':
-            if hasattr(geo.material, '__marin_tangent__'):
-                strains, coeffs = geo.material.__marin_tangent__(strain=strain)
+            if hasattr(geo.material.constitutive_law, '__marin_tangent__'):
+                strains, coeffs = (
+                    geo.material.constitutive_law.__marin_tangent__(
+                        strain=strain
+                    )
+                )
             else:
                 raise AttributeError(
-                    f'The material object {geo.material} of geometry {geo} \
-                    does not have implement the __marin_tangent__ function\
-                    . \
-                    Please implement the function or use another integrato\
-                    r, like '
-                    'Fibre'
-                    ''
+                    'The constitutive law object '
+                    f'{geo.material.constitutive_law} of geometry {geo} does '
+                    'not have implement the __marin_tangent__ function. Please'
+                    ' implement the function or use another integrator, like '
+                    'Fibre.'
                 )
         else:
             raise ValueError(f'Unknown integrate type: {integrate}')
@@ -159,9 +162,11 @@ class MarinIntegrator(SectionIntegrator):
             x.append(xp)
             y.append(yp)
             if integrate == 'stress':
-                IA.append(pg.material.get_stress(strain_) * A)
+                IA.append(pg.material.constitutive_law.get_stress(strain_) * A)
             elif integrate == 'modulus':
-                IA.append(pg.material.get_tangent(strain_) * A)
+                IA.append(
+                    pg.material.constitutive_law.get_tangent(strain_) * A
+                )
         input.append((1, np.array(x), np.array(y), np.array(IA)))
 
     def prepare_input(

--- a/tests/test_geometry/test_circular.py
+++ b/tests/test_geometry/test_circular.py
@@ -6,8 +6,8 @@ import numpy as np
 import pytest
 
 from structuralcodes.geometry import CircularGeometry, add_reinforcement_circle
+from structuralcodes.materials.basic import ElasticMaterial
 from structuralcodes.materials.concrete import ConcreteMC2010
-from structuralcodes.materials.constitutive_laws import Elastic
 from structuralcodes.materials.reinforcement import ReinforcementMC2010
 
 
@@ -18,7 +18,7 @@ from structuralcodes.materials.reinforcement import ReinforcementMC2010
 )
 def test_create_circular_geometry(diameter, n_points):
     """Test creating a CircularGeometry."""
-    mat = Elastic(300000)
+    mat = ElasticMaterial(E=300000, density=2450)
     circle = CircularGeometry(diameter, mat, n_points)
 
     assert len(circle.polygon.exterior.coords) == n_points + 2
@@ -35,7 +35,7 @@ def test_create_circular_geometry(diameter, n_points):
 @pytest.mark.parametrize('wrong_diameter', [-100, 0])
 def test_create_circular_geometry_exception(wrong_diameter):
     """Test raising exception when inputing wrong value."""
-    mat = Elastic(300000)
+    mat = ElasticMaterial(E=300000, density=2450)
     with pytest.raises(ValueError):
         CircularGeometry(wrong_diameter, mat)
 
@@ -48,7 +48,7 @@ def test_create_circular_geometry_exception(wrong_diameter):
 def test_circle_with_origin(origin):
     """Test creating a circle with an origin."""
     # Arrange
-    mat = Elastic(300000)
+    mat = ElasticMaterial(E=300000, density=2450)
     diameter = 100
 
     # Act and assert

--- a/tests/test_geometry/test_geometry.py
+++ b/tests/test_geometry/test_geometry.py
@@ -17,9 +17,13 @@ from structuralcodes.geometry import (
     add_reinforcement_line,
     create_line_point_angle,
 )
+from structuralcodes.materials.basic import (
+    ElasticMaterial,
+    ElasticPlasticMaterial,
+    GenericMaterial,
+)
 from structuralcodes.materials.concrete import ConcreteMC2010
 from structuralcodes.materials.constitutive_laws import (
-    Elastic,
     ElasticPlastic,
     ParabolaRectangle,
 )
@@ -63,7 +67,14 @@ def test_point_geometry():
     """Test creating a PointGeometry object."""
     Geometry.section_counter = 0
     # Create a consitutive law to use
-    steel = ElasticPlastic(210000, 450)
+    constitutive_law_steel = ElasticPlastic(210000, 450)
+    steel = ReinforcementMC2010(
+        fyk=450,
+        Es=210000,
+        ftk=450,
+        epsuk=0.03,
+        constitutive_law=constitutive_law_steel,
+    )
 
     # Create two points with default naming (uses global counter)
     for i in range(2):
@@ -122,7 +133,7 @@ def test_point_geometry():
     # Trick for now since we don't hav a steel material
     C25 = ConcreteMC2010(25)
     p = PointGeometry(np.array([2, 3]), 12, C25)
-    assert isinstance(p.material, ParabolaRectangle)
+    assert isinstance(p.material.constitutive_law, ParabolaRectangle)
 
 
 # Test Surface Geometry
@@ -132,18 +143,20 @@ def test_surface_geometry():  # noqa: PLR0915
     C25 = ConcreteMC2010(25)
 
     # Create a constitutive law to use
-    C25_const = ParabolaRectangle(25)
+    C25_const = GenericMaterial(
+        density=C25.density, constitutive_law=ParabolaRectangle(25)
+    )
 
     # Create a rectangular geometry
     poly = Polygon(((0, 0), (200, 0), (200, 400), (0, 400)))
     for mat in (C25, C25_const):
         geo = SurfaceGeometry(poly, mat)
-        assert isinstance(geo.material, ParabolaRectangle)
+        assert isinstance(geo.material.constitutive_law, ParabolaRectangle)
         assert geo.area == 200 * 400
         assert geo.centroid[0] == 100
         assert geo.centroid[1] == 200
         geo_t = geo.translate(-100, -200)
-        assert isinstance(geo_t.material, ParabolaRectangle)
+        assert isinstance(geo_t.material.constitutive_law, ParabolaRectangle)
         assert geo_t.area == 200 * 400
         assert geo_t.centroid[0] == 0
         assert geo_t.centroid[1] == 0
@@ -216,8 +229,7 @@ def test_surface_geometry():  # noqa: PLR0915
         SurfaceGeometry(poly=poly, material=1)
     assert (
         str(excinfo.value)
-        == f'mat should be a valid structuralcodes.base.Material \
-                or structuralcodes.base.ConstitutiveLaw object. \
+        == f'mat should be a valid structuralcodes.base.Material object. \
                 {repr(1)}'
     )
 
@@ -247,7 +259,12 @@ def test_compound_geometry():
     """Test creating a SurfaceGeometry object."""
     # Create a material to use
     C25 = ConcreteMC2010(25)
-    steel = ElasticPlastic(210000, 450)
+    steel = ReinforcementMC2010(
+        fyk=450,
+        Es=210000,
+        ftk=450,
+        epsuk=0.03,
+    )
 
     # Create a rectangular geometry
     poly = Polygon(((0, 0), (200, 0), (200, 400), (0, 400)))
@@ -309,8 +326,12 @@ def test_compound_geometry():
     geo = CompoundGeometry(multi_pol, [C25, steel])
     assert_geometries_equal(geo.geometries[0].polygon, web)
     assert_geometries_equal(geo.geometries[1].polygon, flange)
-    assert isinstance(geo.geometries[0].material, ParabolaRectangle)
-    assert isinstance(geo.geometries[1].material, ElasticPlastic)
+    assert isinstance(
+        geo.geometries[0].material.constitutive_law, ParabolaRectangle
+    )
+    assert isinstance(
+        geo.geometries[1].material.constitutive_law, ElasticPlastic
+    )
     # check error is raised when the number of materials is incorrect
     with pytest.raises(ValueError) as excinfo:
         CompoundGeometry(multi_pol, [C25, C25, C25])
@@ -341,7 +362,7 @@ def test_add_geometries():
     polys.append(
         Polygon([(-150, -300), (0, -300), (0, -289.3), (-150, -289.3)])
     )
-    mat = ElasticPlastic(E=206000, fy=300)
+    mat = ElasticPlasticMaterial(E=206000, fy=300, density=7850)
     geo1 = SurfaceGeometry(polys[-1], mat)
 
     polys.append(Polygon([(-150, 289.3), (0, 289.3), (0, 300), (-150, 300)]))
@@ -385,7 +406,7 @@ def test_add_geometries():
 
 def test_sub_geometries():
     """Test subtraction between geometries."""
-    mat = ElasticPlastic(E=206000, fy=300)
+    mat = ElasticPlasticMaterial(E=206000, fy=300, density=7850)
     # Create the exptected polygons
     poly_1 = Polygon(
         shell=[(-100, -200), (100, -200), (100, 200), (-100, 200)],
@@ -451,7 +472,7 @@ def test_sub_geometries():
 )
 def test_extents_calculation(w, h):
     """Test extents calculation for SurfaceGeometry and CompoundGeometry."""
-    mat = Elastic(E=206000)
+    mat = ElasticMaterial(E=206000, density=7850)
     # Create a rectangle
     geo_rect = SurfaceGeometry(
         Polygon(
@@ -496,7 +517,7 @@ def test_extents_calculation(w, h):
 )
 def test_property_reinforced_concrete(w, h, c):
     """Test property reinforced_concrete."""
-    mat = Elastic(E=206000)
+    mat = ElasticMaterial(E=206000, density=7850)
     # Create a rectangle
     geo_rect = SurfaceGeometry(
         Polygon(
@@ -509,7 +530,7 @@ def test_property_reinforced_concrete(w, h, c):
         ),
         mat,
     )
-    steel = Elastic(E=206000)
+    steel = ElasticMaterial(E=206000, density=7850)
     geo_rc = add_reinforcement_line(
         geo_rect,
         (-w / 2 + c, -h / 2 + c),

--- a/tests/test_geometry/test_rectangular.py
+++ b/tests/test_geometry/test_rectangular.py
@@ -9,8 +9,8 @@ from structuralcodes.geometry import (
     RectangularGeometry,
     add_reinforcement_line,
 )
+from structuralcodes.materials.basic import ElasticMaterial
 from structuralcodes.materials.concrete import ConcreteMC2010
-from structuralcodes.materials.constitutive_laws import Elastic
 from structuralcodes.materials.reinforcement import ReinforcementMC2010
 
 
@@ -21,7 +21,7 @@ from structuralcodes.materials.reinforcement import ReinforcementMC2010
 )
 def test_create_rectangular_geometry(w, h):
     """Test creating a RectangularGeometry."""
-    mat = Elastic(300000)
+    mat = ElasticMaterial(E=300000, density=2450)
     rect = RectangularGeometry(w, h, mat)
 
     assert math.isclose(rect.width, w)
@@ -47,7 +47,7 @@ def test_create_rectangular_geometry(w, h):
 )
 def test_create_rectangular_geometry_exception(wrong_width, wrong_height):
     """Test raising exception when inputing wrong value."""
-    mat = Elastic(30000)
+    mat = ElasticMaterial(E=30000, density=2450)
     with pytest.raises(ValueError):
         RectangularGeometry(wrong_width, wrong_height, mat)
 
@@ -60,7 +60,7 @@ def test_create_rectangular_geometry_exception(wrong_width, wrong_height):
 def test_rectangle_with_origin(origin):
     """Test creating a rectangle with an origin."""
     # Arrange
-    mat = Elastic(30000)
+    mat = ElasticMaterial(E=30000, density=2450)
     height = 600
     width = 200
 

--- a/tests/test_geometry/test_steel_sections.py
+++ b/tests/test_geometry/test_steel_sections.py
@@ -16,9 +16,12 @@ from structuralcodes.geometry import (
     CompoundGeometry,
     SurfaceGeometry,
 )
+from structuralcodes.materials.basic import (
+    ElasticMaterial,
+    ElasticPlasticMaterial,
+    GenericMaterial,
+)
 from structuralcodes.materials.constitutive_laws import (
-    Elastic,
-    ElasticPlastic,
     UserDefined,
 )
 from structuralcodes.sections._generic import GenericSection
@@ -249,7 +252,7 @@ def test_section_get_polygon(cls, name):
     Es = 206000
     fy = 355
     eps_su = fy / Es
-    steel = ElasticPlastic(E=Es, fy=fy, eps_su=eps_su)
+    steel = ElasticPlasticMaterial(E=Es, fy=fy, density=7850, eps_su=eps_su)
 
     # Create geometry
     geo = SurfaceGeometry(cls.get_polygon(name), steel)
@@ -957,7 +960,7 @@ def test_Isection_elastic_fiber(cls, name):
     Es = 206000
     fy = 355
     eps_su = fy / Es
-    steel = ElasticPlastic(E=Es, fy=fy, eps_su=eps_su)
+    steel = ElasticPlasticMaterial(E=Es, fy=fy, density=7850, eps_su=eps_su)
 
     # Create geometry
     i_beam = cls(name)
@@ -1018,7 +1021,7 @@ def test_Isection_elastic_marin(cls, name):
     Es = 206000
     fy = 355
     eps_su = fy / Es
-    steel = ElasticPlastic(E=Es, fy=fy, eps_su=eps_su)
+    steel = ElasticPlasticMaterial(E=Es, fy=fy, density=7850, eps_su=eps_su)
 
     # Create geometry
     i_beam = cls(name)
@@ -1079,7 +1082,7 @@ def test_Isection_plastic_fiber(cls, name):
     Es = 206000
     fy = 355
     eps_su = 0.15
-    steel = ElasticPlastic(E=Es, fy=fy, eps_su=eps_su)
+    steel = ElasticPlasticMaterial(E=Es, fy=fy, density=7850, eps_su=eps_su)
 
     # Create geometry
     i_beam = cls(name)
@@ -1140,7 +1143,7 @@ def test_Isection_plastic_marin(cls, name):
     Es = 206000
     fy = 355
     eps_su = 0.15
-    steel = ElasticPlastic(E=Es, fy=fy, eps_su=eps_su)
+    steel = ElasticPlasticMaterial(E=Es, fy=fy, density=7850, eps_su=eps_su)
 
     # Create geometry
     i_beam = cls(name)
@@ -1200,8 +1203,8 @@ def test_Isection_elastic_material_marin(cls, name):
     """Test Steel I section elastic strength."""
     Es = 206000
     fy = 355
-    steel = Elastic(E=Es)
-    steel.set_ultimate_strain(fy / Es)
+    steel = ElasticMaterial(E=Es, density=7850)
+    steel.constitutive_law.set_ultimate_strain(fy / Es)
     # Create geometry
     i_beam = cls(name)
     geo = CompoundGeometry([SurfaceGeometry(i_beam.polygon, steel)])
@@ -1261,9 +1264,10 @@ def test_Isection_user_material_marin(cls, name):
     Es = 206000
     fy = 355
     eps_su = 7e-2
-    steel = UserDefined(
+    steel_law = UserDefined(
         x=[-eps_su, -fy / Es, 0, fy / Es, eps_su], y=[-fy, -fy, 0, fy, fy]
     )
+    steel = GenericMaterial(density=7850, constitutive_law=steel_law)
     # Create geometry
     i_beam = cls(name)
     geo = CompoundGeometry([SurfaceGeometry(i_beam.polygon, steel)])
@@ -1421,9 +1425,10 @@ def test_profiles(cls, name, Wyel, Wzel, Wypl, Wzpl):
     Es = 206000
     fy = 355
     eps_su = 7e-2
-    steel = UserDefined(
+    steel_law = UserDefined(
         x=[-eps_su, -fy / Es, 0, fy / Es, eps_su], y=[-fy, -fy, 0, fy, fy]
     )
+    steel = GenericMaterial(density=7850, constitutive_law=steel_law)
     # Create geometry
     beam = cls(name)
 
@@ -1437,7 +1442,7 @@ def test_profiles(cls, name, Wyel, Wzel, Wypl, Wzpl):
     # Create the section with fiber
     sec = GenericSection(geo)
     # Elastic strength
-    steel.set_ultimate_strain(fy / Es)
+    steel_law.set_ultimate_strain(fy / Es)
     results = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
     assert math.isclose(-results.m_y * 1e-6, mye_expected, rel_tol=2.5e-2)
     results = sec.section_calculator.calculate_bending_strength(
@@ -1445,7 +1450,7 @@ def test_profiles(cls, name, Wyel, Wzel, Wypl, Wzpl):
     )
     assert math.isclose(-results.m_z * 1e-6, mze_expected, rel_tol=2.5e-2)
     # Plastic strength
-    steel.set_ultimate_strain(0.07)
+    steel_law.set_ultimate_strain(0.07)
     results = sec.section_calculator.calculate_bending_strength(theta=0, n=0)
     assert math.isclose(-results.m_y * 1e-6, myp_expected, rel_tol=2.5e-2)
     results = sec.section_calculator.calculate_bending_strength(

--- a/tests/test_sections/test_generic_section.py
+++ b/tests/test_sections/test_generic_section.py
@@ -15,8 +15,9 @@ from structuralcodes.geometry import (
     add_reinforcement_circle,
     add_reinforcement_line,
 )
+from structuralcodes.materials.basic import ElasticMaterial
 from structuralcodes.materials.concrete import ConcreteEC2_2004, ConcreteMC2010
-from structuralcodes.materials.constitutive_laws import Elastic, Sargin
+from structuralcodes.materials.constitutive_laws import Sargin
 from structuralcodes.materials.reinforcement import (
     ReinforcementEC2_2004,
     ReinforcementMC2010,
@@ -145,7 +146,7 @@ def test_rectangular_section():
 def test_rectangular_section_tangent_stiffness(b, h, E, integrator):
     """Test stiffness matrix of elastic rectangular section."""
     # Create materials to use
-    elastic = Elastic(E)
+    elastic = ElasticMaterial(E=E, density=2450)
 
     # The section
     poly = Polygon(
@@ -352,7 +353,7 @@ def test_rectangular_rc_section_tangent_stiffness(
 
     # For comparison, let's compare this with a elastic section of only
     # reacting concrete:
-    elastic = Elastic(Ec)
+    elastic = ElasticMaterial(E=Ec, density=concrete.density)
     geo = SurfaceGeometry(
         Polygon(
             (
@@ -412,7 +413,7 @@ def test_rectangular_rc_section_tangent_stiffness(
 def test_rectangular_section_tangent_stiffness_translated(b, h, E, integrator):
     """Test stiffness matrix of elastic rectangular section."""
     # Create materials to use
-    elastic = Elastic(E)
+    elastic = ElasticMaterial(E=E, density=2450)
 
     # The section
     poly = Polygon(((0, 0), (b, 0), (b, h), (0, h)))
@@ -870,7 +871,7 @@ def test_strain_plane_calculation_elastic_Nmm(n, my, mz, Ec, b, h):
     Elastic materials, test many load combinations.
     """
     # Create materials to use
-    concrete = Elastic(Ec)
+    concrete = ElasticMaterial(E=Ec, density=2450)
 
     # Create the section
     geom = SurfaceGeometry(
@@ -944,7 +945,7 @@ def test_strain_plane_calculation_elastic_kNm(n, my, mz, Ec, b, h):
     Units in kN, m and kPa
     """
     # Create materials to use
-    concrete = Elastic(Ec)
+    concrete = ElasticMaterial(E=Ec, density=2450)
 
     # Create the section
     geom = SurfaceGeometry(


### PR DESCRIPTION
Removes the option to pass a constitutive law when creating a geometry. Instead, only material objects are allowed.

The following tasks were done:

- Allow only material objects when creating geometry objects.
- Add basic material objects with basic constitutive laws.
- Update tests.