### PR TITLE
fix: replace misleading variable name in integrate_stress method

### DIFF
--- a/structuralcodes/sections/section_integrators/_shell_integrator.py
+++ b/structuralcodes/sections/section_integrators/_shell_integrator.py
@@ -115,13 +115,13 @@ class ShellFiberIntegrator(SectionIntegrator):
             Tuple(float, float, float, float, float, float):
             The stress resultants Nx, Ny, Nxy, Mx, My, Mxy
         """
-        z, stress_resultants = prepared_input[0]
-        Nx = np.sum(stress_resultants[:, 0])
-        Ny = np.sum(stress_resultants[:, 1])
-        Nxy = np.sum(stress_resultants[:, 2])
-        Mx = np.sum(stress_resultants[:, 0] * z)
-        My = np.sum(stress_resultants[:, 1] * z)
-        Mxy = np.sum(stress_resultants[:, 2] * z)
+        z, stress_array = prepared_input[0]
+        Nx = np.sum(stress_array[:, 0])
+        Ny = np.sum(stress_array[:, 1])
+        Nxy = np.sum(stress_array[:, 2])
+        Mx = np.sum(stress_array[:, 0] * z)
+        My = np.sum(stress_array[:, 1] * z)
+        Mxy = np.sum(stress_array[:, 2] * z)
         return Nx, Ny, Nxy, Mx, My, Mxy
 
     def integrate_modulus(

--- a/structuralcodes/sections/section_integrators/_shell_integrator.py
+++ b/structuralcodes/sections/section_integrators/_shell_integrator.py
@@ -115,13 +115,13 @@ class ShellFiberIntegrator(SectionIntegrator):
             Tuple(float, float, float, float, float, float):
             The stress resultants Nx, Ny, Nxy, Mx, My, Mxy
         """
-        z, stress_array = prepared_input[0]
-        Nx = np.sum(stress_array[:, 0])
-        Ny = np.sum(stress_array[:, 1])
-        Nxy = np.sum(stress_array[:, 2])
-        Mx = np.sum(stress_array[:, 0] * z)
-        My = np.sum(stress_array[:, 1] * z)
-        Mxy = np.sum(stress_array[:, 2] * z)
+        z, fiber_stress = prepared_input[0]
+        Nx = np.sum(fiber_stress[:, 0])
+        Ny = np.sum(fiber_stress[:, 1])
+        Nxy = np.sum(fiber_stress[:, 2])
+        Mx = np.sum(fiber_stress[:, 0] * z)
+        My = np.sum(fiber_stress[:, 1] * z)
+        Mxy = np.sum(fiber_stress[:, 2] * z)
         return Nx, Ny, Nxy, Mx, My, Mxy
 
     def integrate_modulus(


### PR DESCRIPTION
In `integrate_stress`, the unpacking `z, stress_resultants = prepared_input[0]` might be misleading, since `stress_resultants` here is the array of per-fiber stress contributions from `prepare_input`.