### PR TITLE
fix: accept kwargs in the reinforcement factory

### DIFF
--- a/structuralcodes/materials/concrete/__init__.py
+++ b/structuralcodes/materials/concrete/__init__.py
@@ -49,6 +49,9 @@ def create_concrete(
             desired standard. If None (default) the globally used design
             standard will be adopted. Otherwise the design standard specified
             will be used for the instance of the material.
+        **kwargs: Other valid keyword arguments that are collected and passed
+            to the specific concrete material. Please inspect the documentation
+            of the other concrete materials to see valid arguments.
 
     Raises:
         ValueError: if the design code is not valid or does not cover concrete

--- a/structuralcodes/materials/reinforcement/__init__.py
+++ b/structuralcodes/materials/reinforcement/__init__.py
@@ -51,6 +51,10 @@ def create_reinforcement(
             desired standard. If None (default) the globally used design
             standard will be adopted. Otherwise the design standard specified
             will be used for the instance of the material.
+        **kwargs: Other valid keyword arguments that are collected and passed
+            to the specific reinforcement material. Please inspect the
+            documentation of the other reinforcement materials to see valid
+            arguments.
 
     Raises:
         ValueError: If the design code is not valid or does not cover


### PR DESCRIPTION
This fixes an inconsistency between the concrete factory and the reinforcement factory. `kwargs` like for example `constitutive_law` are now passed further to the specific reinforcement material.