### PR TITLE
fix: Update __sargin__  with k_sargin computed using fcd and not fcm

### DIFF
--- a/structuralcodes/materials/concrete/_concreteEC2_2004.py
+++ b/structuralcodes/materials/concrete/_concreteEC2_2004.py
@@ -506,11 +506,19 @@ class ConcreteEC2_2004(Concrete):  # noqa: N801
 
     def __sargin__(self) -> dict:
         """Returns kwargs for creating a Sargin const law."""
+        if self._k_sargin is None:
+            k_sargin_design = ec2_2004.k_sargin(
+                Ecm=self.Ecm,
+                fcm=self.fcd(),
+                eps_c1=self.eps_c1,
+            )
+        else:
+            k_sargin_design = self._k_sargin
         return {
             'fc': self.fcd(),
             'eps_c1': self.eps_c1,
             'eps_cu1': self.eps_cu1,
-            'k': self.k_sargin,
+            'k': k_sargin_design,
         }
 
     def __popovics__(self) -> dict:

--- a/structuralcodes/materials/concrete/_concreteEC2_2004.py
+++ b/structuralcodes/materials/concrete/_concreteEC2_2004.py
@@ -507,7 +507,7 @@ class ConcreteEC2_2004(Concrete):  # noqa: N801
     def __sargin__(self) -> dict:
         """Returns kwargs for creating a Sargin const law."""
         return {
-            'fc': self.fcd(),
+            'fc': self.fcm,
             'eps_c1': self.eps_c1,
             'eps_cu1': self.eps_cu1,
             'k': self.k_sargin,

--- a/structuralcodes/materials/concrete/_concreteEC2_2004.py
+++ b/structuralcodes/materials/concrete/_concreteEC2_2004.py
@@ -506,19 +506,11 @@ class ConcreteEC2_2004(Concrete):  # noqa: N801
 
     def __sargin__(self) -> dict:
         """Returns kwargs for creating a Sargin const law."""
-        if self._k_sargin is None:
-            k_sargin_design = ec2_2004.k_sargin(
-                Ecm=self.Ecm,
-                fcm=self.fcd(),
-                eps_c1=self.eps_c1,
-            )
-        else:
-            k_sargin_design = self._k_sargin
         return {
             'fc': self.fcd(),
             'eps_c1': self.eps_c1,
             'eps_cu1': self.eps_cu1,
-            'k': k_sargin_design,
+            'k': self.k_sargin,
         }
 
     def __popovics__(self) -> dict:

--- a/structuralcodes/materials/concrete/_concreteEC2_2023.py
+++ b/structuralcodes/materials/concrete/_concreteEC2_2023.py
@@ -476,19 +476,11 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
 
     def __sargin__(self) -> dict:
         """Returns kwargs for creating a Sargin const law."""
-        if self._k_sargin is None:
-            k_sargin_design = ec2_2023.k_sargin(
-                Ecm=self.Ecm,
-                fcm=self.fcd(),
-                eps_c1=self.eps_c1,
-            )
-        else:
-            k_sargin_design = self._k_sargin
         return {
             'fc': self.fcd(),
             'eps_c1': self.eps_c1,
             'eps_cu1': self.eps_cu1,
-            'k': k_sargin_design,
+            'k': self.k_sargin,
         }
 
     def __popovics__(self) -> dict:

--- a/structuralcodes/materials/concrete/_concreteEC2_2023.py
+++ b/structuralcodes/materials/concrete/_concreteEC2_2023.py
@@ -477,7 +477,7 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
     def __sargin__(self) -> dict:
         """Returns kwargs for creating a Sargin const law."""
         return {
-            'fc': self.fcd(),
+            'fc': self.fcm,
             'eps_c1': self.eps_c1,
             'eps_cu1': self.eps_cu1,
             'k': self.k_sargin,

--- a/structuralcodes/materials/concrete/_concreteEC2_2023.py
+++ b/structuralcodes/materials/concrete/_concreteEC2_2023.py
@@ -476,11 +476,19 @@ class ConcreteEC2_2023(Concrete):  # noqa: N801
 
     def __sargin__(self) -> dict:
         """Returns kwargs for creating a Sargin const law."""
+        if self._k_sargin is None:
+            k_sargin_design = ec2_2023.k_sargin(
+                Ecm=self.Ecm,
+                fcm=self.fcd(),
+                eps_c1=self.eps_c1,
+            )
+        else:
+            k_sargin_design = self._k_sargin
         return {
             'fc': self.fcd(),
             'eps_c1': self.eps_c1,
             'eps_cu1': self.eps_cu1,
-            'k': self.k_sargin,
+            'k': k_sargin_design,
         }
 
     def __popovics__(self) -> dict:

--- a/structuralcodes/materials/concrete/_concreteMC2010.py
+++ b/structuralcodes/materials/concrete/_concreteMC2010.py
@@ -523,7 +523,7 @@ class ConcreteMC2010(Concrete):
     def __sargin__(self) -> dict:
         """Returns kwargs for creating a Sargin const law."""
         return {
-            'fc': self.fcd(),
+            'fc': self.fcm,
             'eps_c1': self.eps_c1,
             'eps_cu1': self.eps_cu1,
             'k': self.k_sargin,


### PR DESCRIPTION
This PR is a tentative solution for fixing the wrong initial stiffness read by `get_tangent(0.0)` method in `concrete`. 
The relation k_sargin (taken from (3.14) in EC2 was computed with reference to `fcm`. This PR makes this calculation with reference to fcd. The tests are broken now of course, but I will update them if we decide this could be the correct solution.

See the difference between the old (dashed orange line) and the current implementation (blue solid line).

<img width="562" height="455" alt="image" src="https://github.com/user-attachments/assets/5c0356f3-ed8e-4523-b782-e12a218e8a79" />

This has ben corrected for EC2 2004 and EC2 2023. Not for MC2010 that is more tricky since gives values for given fck in a tabular format so making it harder deciding how to correct it when the law represents `fcd` instead of `fcm`.

<img width="562" height="455" alt="image" src="https://github.com/user-attachments/assets/b4f8a510-0d0a-4080-82a5-a2cdce40f484" />

