### PR TITLE
fix: make sure VRdc according to EC2-2004 is non-negative

### DIFF
--- a/structuralcodes/codes/ec2_2004/shear.py
+++ b/structuralcodes/codes/ec2_2004/shear.py
@@ -203,14 +203,15 @@ def VRdc(
         float: The concrete shear resistance in MPa.
     """
     CRdc = CRdc or 0.18 / gamma_c
-    return (
+    return max(
         max(
             CRdc * _k(d) * (100 * _rho_L(Asl, bw, d) * fck) ** (1.0 / 3.0)
             + k1 * _sigma_cp(NEd, Ac, fcd),  # VRdc
             vmin(fck, d) + k1 * _sigma_cp(NEd, Ac, fcd),  # VRdcmin
         )
         * bw
-        * d
+        * d,
+        0,
     )
 
 

--- a/tests/test_ec2_2004/test_ec2_2004_shear.py
+++ b/tests/test_ec2_2004/test_ec2_2004_shear.py
@@ -118,6 +118,27 @@ def test_VRdc(fck, d, Asl, bw, Ned, Ac, k1, gamma_c, expected):
     )
 
 
+@pytest.mark.parametrize('NEd', (500e3, 200e3, 0, -200e3, -500e3))
+def test_VRdc_not_negative(NEd):
+    """Test if VRdc always returns a non-negative number."""
+    fck = 35
+    gamma_c = 1.5
+    assert (
+        shear.VRdc(
+            fck=fck,
+            d=250,
+            Asl=400,
+            bw=100,
+            NEd=NEd,
+            Ac=30000,
+            fcd=fcd(fck=fck, alpha_cc=0.85, gamma_c=gamma_c),
+            k1=0.15,
+            gamma_c=gamma_c,
+        )
+        >= 0
+    )
+
+
 @pytest.mark.parametrize(
     'Iy, bw, S, fctd, NEd, Ac, L_x, L_pt2, expected',
     [


### PR DESCRIPTION
A large axial force in tension could result in a negative shear capacity. This fixes the behavior, and ensures the capacity is non-negative.