### PR TITLE
feat: use warning and not exception to indicate no convergence

### DIFF
--- a/structuralcodes/__init__.py
+++ b/structuralcodes/__init__.py
@@ -1,7 +1,10 @@
 """A Python package that contains models from structural design codes."""
 
+import warnings
+
 from . import codes, core, geometry, materials, sections
 from .codes import get_design_codes, set_design_code, set_national_annex
+from .core.errors import StructuralCodesWarning
 
 __version__ = '0.6.0'
 
@@ -15,3 +18,5 @@ __all__ = [
     'geometry',
     'sections',
 ]
+
+warnings.filterwarnings(action='always', category=StructuralCodesWarning)

--- a/structuralcodes/core/errors.py
+++ b/structuralcodes/core/errors.py
@@ -1,0 +1,11 @@
+"""General exception and warning classes."""
+
+
+class StructuralCodesWarning(Warning):
+    """Base class for StructurlCodes warnings."""
+
+
+class NoConvergenceWarning(StructuralCodesWarning):
+    """A warning that indicates that no convergence was reached for an
+    iterative solver.
+    """

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -14,6 +14,7 @@ from shapely.ops import unary_union
 
 import structuralcodes.core._section_results as s_res
 from structuralcodes.core.base import Section, SectionCalculator
+from structuralcodes.core.errors import NoConvergenceWarning
 from structuralcodes.geometry import (
     CompoundGeometry,
     PointGeometry,
@@ -1474,6 +1475,12 @@ class GenericSectionCalculator(SectionCalculator):
                 break
 
         if num_iter >= max_iter:
-            raise StopIteration('Maximum number of iterations reached.')
+            warnings.warn(
+                message=(
+                    'Maximum number of iterations reached. '
+                    'Please review the strain profile carefully.'
+                ),
+                category=NoConvergenceWarning,
+            )
 
         return strain.tolist()

--- a/tests/test_sections/test_generic_section.py
+++ b/tests/test_sections/test_generic_section.py
@@ -7,6 +7,7 @@ import pytest
 from shapely import Polygon
 
 from structuralcodes.codes.ec2_2004 import reinforcement_duct_props
+from structuralcodes.core.errors import NoConvergenceWarning
 from structuralcodes.geometry import (
     CircularGeometry,
     RectangularGeometry,
@@ -1109,8 +1110,8 @@ def test_strain_plane_calculation_rectangular_rc_high_load(
 
     # Check that with given loads we don't reach convergence
     section = GenericSection(geo)
-    with pytest.raises(
-        StopIteration, match='Maximum number of iterations reached'
+    with pytest.warns(
+        NoConvergenceWarning, match='Maximum number of iterations reached'
     ):
         section.section_calculator.calculate_strain_profile(
             n, my, mz, tol=1e-7


### PR DESCRIPTION
This is an experiment to use warnings instead of exceptions to indicate that an iterative solution does not reach convergence.

When no convergence is reached, it can be useful to return some calculation results to the user, so that these results can be examined, and measures can be implemented.

In the current implementation, no convergence is indicated by raising an exception, and therefore, no results are returned from the iterative solver. In this PR, a custom warning is shown instead, and the results at the time of the warning was shown are returned to the user.

To make sure that the warning is always shown, a custom filter is added. The user can always override this behavior, e.g. only showing it once, completely ignoring it, or even raising it as an error.