### PR TITLE
Get stress at point yz

### DIFF
--- a/structuralcodes/core/_section_results.py
+++ b/structuralcodes/core/_section_results.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations  # To have clean hints of ArrayLike in docs
 
+import typing as t
 from dataclasses import dataclass, field, fields
 
 import numpy as np
@@ -264,3 +265,25 @@ class MMInteractionDomain(InteractionDomain):
 
     num_theta: float = 0  # number of discretizations along the angle
     theta: ArrayLike = None  # Array with shape (n,) containing the angle of NA
+
+
+@dataclass
+class PointStressResult:
+    """Class for storing stress results at a specific point in a section.
+
+    Attributes:
+        y (float): Y-coordinate of the point.
+        z (float): Z-coordinate of the point.
+        strain (float): Strain at the point.
+        stress (float): Stress at the point.
+        geometry_name (str, optional): Name of the geometry containing the
+            point.
+        geometry_group_label (str, optional): Group label of the geometry
+    """
+
+    y: float = 0.0
+    z: float = 0.0
+    strain: float = 0.0
+    stress: float = 0.0
+    geometry_name: t.Optional[str] = None
+    geometry_group_label: t.Optional[str] = None


### PR DESCRIPTION
I’m adding a new feature to obtain the stress at any coordinates of the section. 

Feel free to comment on any other changes regarding the functionality of the method or how I’ve integrated it into the repository.

Here’s an example:

```python
from shapely import Polygon

from structuralcodes import set_design_code
from structuralcodes.geometry import SurfaceGeometry, add_reinforcement
from structuralcodes.materials.concrete import create_concrete
from structuralcodes.materials.reinforcement import create_reinforcement
from structuralcodes.sections import GenericSection

# Set the active design code
set_design_code('ec2_2004')
# Create a concrete and a reinforcement
fck = 45
fyk = 500
ftk = 550
Es = 200000
epsuk = 0.07

# These factory functions create concrete and reinforcement materials according
# to the globally set design code
concrete = create_concrete(fck=fck)
reinforcement = create_reinforcement(fyk=fyk, Es=Es, ftk=ftk, epsuk=epsuk)


# Create a rectangular geometry
width = 250
height = 500
polygon = Polygon(
    [
        (-width / 2, -height / 2),
        (width / 2, -height / 2),
        (width / 2, height / 2),
        (-width / 2, height / 2),
    ]
)  # We leverage shapely to create geometries
geometry = SurfaceGeometry(
    poly=polygon, material=concrete, group_label='concrete'
)  # A SurfaceGeometry is a shapely Polygon with an assigned material


# Add reinforcement
diameter_reinf = 25
cover = 50

geometry = add_reinforcement(
    geometry,
    (
        -width / 2 + cover + diameter_reinf / 2,
        -height / 2 + cover + diameter_reinf / 2,
    ),
    diameter_reinf,
    reinforcement,
    group_label='bar 1',
)  # The add_reinforcement function returns a CompoundGeometry
geometry = add_reinforcement(
    geometry,
    (
        width / 2 - cover - diameter_reinf / 2,
        -height / 2 + cover + diameter_reinf / 2,
    ),
    diameter_reinf,
    reinforcement,
    group_label='bar 2',
)

# Create section
section = GenericSection(geometry)
section.geometry
```
Now, the calculation of the stress at certain coordinates for a bending moment of 200 kN·m and an axial compression of 200 kN.

```python
strain = section.section_calculator.calculate_strain_profile(
    n=-200.0 * 1e3,
    my=-200.0 * 1e6,
    mz=0.0 * 1e6,
)

results = section.section_calculator.get_stress_point(
    y=width / 2 - cover - diameter_reinf / 2,
    z=-height / 2 + cover + diameter_reinf / 2,
    eps_a=strain[0],
    chi_y=strain[1],
    chi_z=strain[2],
    where=0,
)

if results:
    for result in results:
        print(f'Stres in ({result.y}, {result.z}): {result.stress}')
        print(f'Strain: {result.strain}')
        print(f'Geometry: {result.geometry_group_label}')
        print('---')
else:
    print('Point outside any geometry')

```