### PR TITLE
chore: force python 3.13 in action for publishing docs

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.x"
+        python-version: "3.13"
     - name: Install deps
       run: |
         python -m pip install --upgrade pip uv


### PR DESCRIPTION
Since `triangle` is not yet supported on Python 3.14, we need to pin Python 3.13 in the action for publishing the docs.