### PR TITLE
feat: filtering geometries based on name and group label

### DIFF
--- a/docs/api/geometry/geometry_creation.md
+++ b/docs/api/geometry/geometry_creation.md
@@ -62,6 +62,9 @@
     .. automethod:: mirror
 
     .. automethod:: calculate_extents
+    
+    .. automethod:: name_filter
+    .. automethod:: group_filter
 
     .. automethod:: from_geometry
 

--- a/structuralcodes/geometry/_geometry.py
+++ b/structuralcodes/geometry/_geometry.py
@@ -4,6 +4,7 @@ from __future__ import annotations  # To have clean hints of ArrayLike in docs
 
 import typing as t
 import warnings
+from fnmatch import fnmatchcase
 from math import atan2
 
 import numpy as np
@@ -123,6 +124,68 @@ class Geometry:
             CompoundGeometry: A new CompoundGeometry.
         """
         return CompoundGeometry([self, other])
+
+    def _name_matches(
+        self, pattern: str, *, case_sensitive: bool = True
+    ) -> bool:
+        """Checks if the name matches a pattern.
+
+        Arguments:
+            pattern (str): the string pattern to be checked
+
+        Keywordarguments:
+            case_sensitive (bool, optional): if True (default) the check is
+                case sensitive.
+
+        Returns:
+            (bool): Returns True if the name matches the pattern.
+
+        Notes:
+            The matching permits to use:
+                - "*" any chars
+                - "?" single char
+                - "[abc]" character set
+
+        Examples:
+            geo.name_matches("nametos*")
+            geo.name_matches("*pier*")
+            geo.name_matches("Abutment??", case_senstive=False)
+        """
+        if not case_sensitive:
+            return fnmatchcase(self.name.casefold(), pattern.casefold())
+        return fnmatchcase(self.name, pattern)
+
+    def _group_matches(
+        self, pattern: str, *, case_sensitive: bool = True
+    ) -> bool:
+        """Checks if the group_label matches a pattern.
+
+        Arguments:
+            pattern (str): the string pattern to be checked
+
+        Keywordarguments:
+            case_sensitive (bool, optional): if True (default) the check is
+                case sensitive.
+
+        Returns:
+            (bool): Returns True if the group_label matches the pattern.
+
+        Notes:
+            The matching permits to use:
+                - "*" any chars
+                - "?" single char
+                - "[abc]" character set
+
+        Examples:
+            geo.group_matches("nametos*")
+            geo.group_matches("*pier*")
+            geo.group_matches("Abutment??", case_senstive=False)
+        """
+        if self.group_label is None:
+            return False
+        if not case_sensitive:
+            return fnmatchcase(self.group_label.casefold(), pattern.casefold())
+        return fnmatchcase(self.group_label, pattern)
 
 
 class PointGeometry(Geometry):
@@ -933,3 +996,85 @@ class CompoundGeometry(Geometry):
                 PointGeometry.from_geometry(geo=pg, new_material=new_material)
             )
         return CompoundGeometry(geometries=processed_geoms)
+
+    def name_filter(
+        self,
+        pattern: t.Optional[str],
+        *,
+        case_sensitive: bool = True,
+        return_mode: t.Literal['flat', 'split'] = 'flat',
+    ) -> t.Union[t.List[Geometry], t.Dict[str, t.List[Geometry]]]:
+        """Filters by name the geometries.
+
+        This method returns the list of geometries whose name matches a given
+        pattern.
+
+        Argument:
+            pattern (str, optional): the string with the pattern to match.
+                If None, all the geometries are returned.
+
+        Keyword Arguments:
+            case_senstive (bool, optional): if True (default) the match is case
+                sensitive.
+            return_mode (str, optional): if 'flat' (default) the method returns
+                a single list with both SurfaceGeometry and PointGeometry. If
+                'split' a dictionary is returning separing the SurfaceGeometry
+                from PointGeometry.
+        """
+        surfaces = self.geometries
+        points = self.point_geometries
+
+        if pattern:
+            surfaces = [
+                g
+                for g in surfaces
+                if g._name_matches(pattern, case_sensitive=case_sensitive)
+            ]
+            points = [
+                g
+                for g in points
+                if g._name_matches(pattern, case_sensitive=case_sensitive)
+            ]
+        if return_mode == 'flat':
+            return [*surfaces, *points]
+        return {'surfaces': surfaces, 'points': points}
+
+    def group_matches(
+        self,
+        pattern: str,
+        *,
+        case_sensitive: bool = True,
+        return_mode: t.Literal['flat', 'split'] = 'flat',
+    ) -> t.Union[t.List[Geometry], t.Dict[str, t.List[Geometry]]]:
+        """Filters by group_label the geometries.
+
+        This method returns the list of geometries whose group_label matches a
+        given pattern.
+
+        Argument:
+            pattern (str): the string with the pattern to match.
+
+        Keyword Arguments:
+            case_senstive (bool, optional): if True (default) the match is case
+                sensitive.
+            return_mode (str, optional): if 'flat' (default) the method returns
+                a single list with both SurfaceGeometry and PointGeometry. If
+                'split' a dictionary is returning separing the SurfaceGeometry
+                from PointGeometry.
+        """
+        surfaces = self.geometries
+        points = self.point_geometries
+
+        surfaces = [
+            g
+            for g in surfaces
+            if g._group_matches(pattern, case_sensitive=case_sensitive)
+        ]
+        points = [
+            g
+            for g in points
+            if g._group_matches(pattern, case_sensitive=case_sensitive)
+        ]
+        if return_mode == 'flat':
+            return [*surfaces, *points]
+        return {'surfaces': surfaces, 'points': points}

--- a/structuralcodes/geometry/_geometry.py
+++ b/structuralcodes/geometry/_geometry.py
@@ -133,23 +133,23 @@ class Geometry:
         Arguments:
             pattern (str): the string pattern to be checked
 
-        Keywordarguments:
+        Keyword Arguments:
             case_sensitive (bool, optional): if True (default) the check is
                 case sensitive.
 
         Returns:
             (bool): Returns True if the name matches the pattern.
 
-        Notes:
+        Note:
             The matching permits to use:
                 - "*" any chars
                 - "?" single char
                 - "[abc]" character set
 
         Examples:
-            geo.name_matches("nametos*")
-            geo.name_matches("*pier*")
-            geo.name_matches("Abutment??", case_senstive=False)
+            >>> geo.name_matches("nametos*")
+            >>> geo.name_matches("*pier*")
+            >>> geo.name_matches("Abutment??", case_senstive=False)
         """
         if not case_sensitive:
             return fnmatchcase(self.name.casefold(), pattern.casefold())
@@ -163,23 +163,23 @@ class Geometry:
         Arguments:
             pattern (str): the string pattern to be checked
 
-        Keywordarguments:
+        Keyword Arguments:
             case_sensitive (bool, optional): if True (default) the check is
                 case sensitive.
 
         Returns:
             (bool): Returns True if the group_label matches the pattern.
 
-        Notes:
+        Note:
             The matching permits to use:
                 - "*" any chars
                 - "?" single char
                 - "[abc]" character set
 
         Examples:
-            geo.group_matches("nametos*")
-            geo.group_matches("*pier*")
-            geo.group_matches("Abutment??", case_senstive=False)
+            >>> geo.group_matches("nametos*")
+            >>> geo.group_matches("*pier*")
+            >>> geo.group_matches("Abutment??", case_senstive=False)
         """
         if self.group_label is None:
             return False
@@ -1008,30 +1008,26 @@ class CompoundGeometry(Geometry):
 
         This method returns the geometries whose name matches a given pattern.
 
-        Args:
+        Arguments:
             pattern (str | None, optional): Pattern used to match geometry
-                names.
-                If ``None``, all geometries are returned.
+                names. If ``None``, all geometries are returned.
 
+        Keyword Arguments:
             case_sensitive (bool, optional): If ``True`` (default), the match
                 is case-sensitive.
-
-            return_mode (str, optional): Controls the return format:
-
-                * ``"flat"`` (default): return a single list containing both
-                    ``SurfaceGeometry`` and ``PointGeometry`` objects.
-                * ``"split"``: return a dictionary separating the two types.
+            return_mode (str, optional): Controls the return format. ``"flat"``
+                (default): return a single list containing both
+                ``SurfaceGeometry`` and ``PointGeometry`` objects. ``"split"``:
+                return a dictionary separating the two types.
 
         Returns:
-            list[Geometry] | dict[str, list[Geometry]]: The filtered geometries
+            list[Geometry] | dict[str, list[Geometry]]: The filtered
+            geometries. If ``return_mode="flat"``, a single list containing
+            both ``SurfaceGeometry`` and ``PointGeometry`` objects is returned.
+            If ``return_mode="split"``, a dictionary with keys ``"surfaces"``
+            and ``"points"`` is returned.
 
-                * If ``return_mode="flat"``, a single list containing both
-                    ``SurfaceGeometry`` and ``PointGeometry`` objects is
-                    returned.
-                * If ``return_mode="split"``, a dictionary with keys
-                    ``"surfaces"`` and ``"points"`` is returned.
-
-        Notes:
+        Note:
             The pattern supports simple wildcard matching:
 
             * ``*`` matches any sequence of characters
@@ -1081,30 +1077,26 @@ class CompoundGeometry(Geometry):
         This method returns the geometries whose group_label matches a given
         pattern.
 
-        Args:
+        Arguments:
             pattern (str | None, optional): Pattern used to match geometry
-                group labels.
-                If ``None``, all geometries are returned.
+                group labels. If ``None``, all geometries are returned.
 
+        Keyword Arguments:
             case_sensitive (bool, optional): If ``True`` (default), the match
                 is case-sensitive.
-
-            return_mode (str, optional): Controls the return format:
-
-                * ``"flat"`` (default): return a single list containing both
-                    `SurfaceGeometry`` and ``PointGeometry`` objects.
-                * ``"split"``: return a dictionary separating the two types.
+            return_mode (str, optional): Controls the return format. ``"flat"``
+                (default): return a single list containing both
+                `SurfaceGeometry`` and ``PointGeometry`` objects. ``"split"``:
+                return a dictionary separating the two types.
 
         Returns:
-            list[Geometry] | dict[str, list[Geometry]]: The filtered geometries
+            list[Geometry] | dict[str, list[Geometry]]: The filtered
+            geometries. If ``return_mode="flat"``, a single list containing
+            both ``SurfaceGeometry`` and ``PointGeometry`` objects is returned.
+            If ``return_mode="split"``, a dictionary with keys ``"surfaces"``
+            and ``"points"`` is returned.
 
-                * If ``return_mode="flat"``, a single list containing both
-                    ``SurfaceGeometry`` and ``PointGeometry`` objects is
-                    returned.
-                * If ``return_mode="split"``, a dictionary with keys
-                    ``"surfaces"`` and ``"points"`` is returned.
-
-        Notes:
+        Note:
             The pattern supports simple wildcard matching:
 
             * ``*`` matches any sequence of characters

--- a/structuralcodes/geometry/_geometry.py
+++ b/structuralcodes/geometry/_geometry.py
@@ -1039,7 +1039,7 @@ class CompoundGeometry(Geometry):
             return [*surfaces, *points]
         return {'surfaces': surfaces, 'points': points}
 
-    def group_matches(
+    def group_filter(
         self,
         pattern: str,
         *,
@@ -1065,16 +1065,17 @@ class CompoundGeometry(Geometry):
         surfaces = self.geometries
         points = self.point_geometries
 
-        surfaces = [
-            g
-            for g in surfaces
-            if g._group_matches(pattern, case_sensitive=case_sensitive)
-        ]
-        points = [
-            g
-            for g in points
-            if g._group_matches(pattern, case_sensitive=case_sensitive)
-        ]
+        if pattern:
+            surfaces = [
+                g
+                for g in surfaces
+                if g._group_matches(pattern, case_sensitive=case_sensitive)
+            ]
+            points = [
+                g
+                for g in points
+                if g._group_matches(pattern, case_sensitive=case_sensitive)
+            ]
         if return_mode == 'flat':
             return [*surfaces, *points]
         return {'surfaces': surfaces, 'points': points}

--- a/structuralcodes/geometry/_geometry.py
+++ b/structuralcodes/geometry/_geometry.py
@@ -1004,22 +1004,52 @@ class CompoundGeometry(Geometry):
         case_sensitive: bool = True,
         return_mode: t.Literal['flat', 'split'] = 'flat',
     ) -> t.Union[t.List[Geometry], t.Dict[str, t.List[Geometry]]]:
-        """Filters by name the geometries.
+        """Filter geometries by name using a pattern.
 
-        This method returns the list of geometries whose name matches a given
-        pattern.
+        This method returns the geometries whose name matches a given pattern.
 
-        Argument:
-            pattern (str, optional): the string with the pattern to match.
-                If None, all the geometries are returned.
+        Args:
+            pattern (str | None, optional): Pattern used to match geometry
+                names.
+                If ``None``, all geometries are returned.
 
-        Keyword Arguments:
-            case_senstive (bool, optional): if True (default) the match is case
-                sensitive.
-            return_mode (str, optional): if 'flat' (default) the method returns
-                a single list with both SurfaceGeometry and PointGeometry. If
-                'split' a dictionary is returning separing the SurfaceGeometry
-                from PointGeometry.
+            case_sensitive (bool, optional): If ``True`` (default), the match
+                is case-sensitive.
+
+            return_mode (str, optional): Controls the return format:
+
+                * ``"flat"`` (default): return a single list containing both
+                    ``SurfaceGeometry`` and ``PointGeometry`` objects.
+                * ``"split"``: return a dictionary separating the two types.
+
+        Returns:
+            list[Geometry] | dict[str, list[Geometry]]: The filtered geometries
+
+                * If ``return_mode="flat"``, a single list containing both
+                    ``SurfaceGeometry`` and ``PointGeometry`` objects is
+                    returned.
+                * If ``return_mode="split"``, a dictionary with keys
+                    ``"surfaces"`` and ``"points"`` is returned.
+
+        Notes:
+            The pattern supports simple wildcard matching:
+
+            * ``*`` matches any sequence of characters
+            * ``?`` matches a single character
+            * ``[abc]`` matches any character in the set
+
+        Examples:
+            Match geometries whose name starts with ``"nametos"``:
+
+            >>> geo.name_filter("nametos*")
+
+            Match geometries containing ``"pier"``:
+
+            >>> geo.name_filter("*pier*")
+
+            Case-insensitive match:
+
+            >>> geo.name_filter("Abutment??", case_sensitive=False)
         """
         surfaces = self.geometries
         points = self.point_geometries
@@ -1041,26 +1071,58 @@ class CompoundGeometry(Geometry):
 
     def group_filter(
         self,
-        pattern: str,
+        pattern: t.Optional[str],
         *,
         case_sensitive: bool = True,
         return_mode: t.Literal['flat', 'split'] = 'flat',
     ) -> t.Union[t.List[Geometry], t.Dict[str, t.List[Geometry]]]:
-        """Filters by group_label the geometries.
+        """Filter geometries by group_label using a pattern.
 
-        This method returns the list of geometries whose group_label matches a
-        given pattern.
+        This method returns the geometries whose group_label matches a given
+        pattern.
 
-        Argument:
-            pattern (str): the string with the pattern to match.
+        Args:
+            pattern (str | None, optional): Pattern used to match geometry
+                group labels.
+                If ``None``, all geometries are returned.
 
-        Keyword Arguments:
-            case_senstive (bool, optional): if True (default) the match is case
-                sensitive.
-            return_mode (str, optional): if 'flat' (default) the method returns
-                a single list with both SurfaceGeometry and PointGeometry. If
-                'split' a dictionary is returning separing the SurfaceGeometry
-                from PointGeometry.
+            case_sensitive (bool, optional): If ``True`` (default), the match
+                is case-sensitive.
+
+            return_mode (str, optional): Controls the return format:
+
+                * ``"flat"`` (default): return a single list containing both
+                    `SurfaceGeometry`` and ``PointGeometry`` objects.
+                * ``"split"``: return a dictionary separating the two types.
+
+        Returns:
+            list[Geometry] | dict[str, list[Geometry]]: The filtered geometries
+
+                * If ``return_mode="flat"``, a single list containing both
+                    ``SurfaceGeometry`` and ``PointGeometry`` objects is
+                    returned.
+                * If ``return_mode="split"``, a dictionary with keys
+                    ``"surfaces"`` and ``"points"`` is returned.
+
+        Notes:
+            The pattern supports simple wildcard matching:
+
+            * ``*`` matches any sequence of characters
+            * ``?`` matches a single character
+            * ``[abc]`` matches any character in the set
+
+        Examples:
+            Match geometries whose group_label starts with ``"grouptos"``:
+
+            >>> geo.group_filter("grouptos*")
+
+            Match geometries containing ``"pier"``:
+
+            >>> geo.group_filter("*pier*")
+
+            Case-insensitive match:
+
+            >>> geo.group_filter("Abutment??", case_sensitive=False)
         """
         surfaces = self.geometries
         points = self.point_geometries

--- a/tests/test_geometry/test_filtering.py
+++ b/tests/test_geometry/test_filtering.py
@@ -1,0 +1,159 @@
+"""Tests for geometry filtering methods."""
+
+import pytest
+
+from structuralcodes.geometry import (
+    RectangularGeometry,
+    add_reinforcement_line,
+)
+from structuralcodes.materials.basic import ElasticMaterial
+
+
+@pytest.fixture
+def reinforced_t_section_geometry():
+    """Create a T section with two named surfaces and grouped reinforcement."""
+    concrete = ElasticMaterial(E=30000, density=2450)
+    reinforcement = ElasticMaterial(E=200000, density=7850)
+
+    geo = RectangularGeometry(
+        width=200,
+        height=400,
+        material=concrete,
+        name='web',
+    )
+    geo += RectangularGeometry(
+        width=800,
+        height=150,
+        material=concrete,
+        origin=(0, 275),
+        name='flange',
+    )
+
+    geo = add_reinforcement_line(
+        geo,
+        coords_i=(-60, -160),
+        coords_j=(60, -160),
+        diameter=16,
+        n=4,
+        material=reinforcement,
+        group_label='bottom_reinforcement',
+    )
+    return add_reinforcement_line(
+        geo,
+        coords_i=(-360, 310),
+        coords_j=(360, 310),
+        diameter=12,
+        n=12,
+        material=reinforcement,
+        group_label='top_reinforcement',
+    )
+
+
+def test_name_filter_none_returns_all_geometries_flat(
+    reinforced_t_section_geometry,
+):
+    """Test filtering by name with pattern=None and flat return mode."""
+    geo = reinforced_t_section_geometry
+
+    filtered = geo.name_filter(None)
+
+    assert len(filtered) == 18
+    assert len(geo.geometries) == 2
+    assert len(geo.point_geometries) == 16
+
+
+def test_name_filter_none_returns_split_dict(reinforced_t_section_geometry):
+    """Test filtering by name with pattern=None and split return mode."""
+    geo = reinforced_t_section_geometry
+
+    filtered = geo.name_filter(None, return_mode='split')
+
+    assert set(filtered.keys()) == {'surfaces', 'points'}
+    assert len(filtered['surfaces']) == 2
+    assert len(filtered['points']) == 16
+
+
+def test_name_filter_exact_surface_name(reinforced_t_section_geometry):
+    """Test filtering by exact surface name."""
+    geo = reinforced_t_section_geometry
+
+    filtered = geo.name_filter('web', return_mode='split')
+
+    assert len(filtered['surfaces']) == 1
+    assert filtered['surfaces'][0].name == 'web'
+    assert len(filtered['points']) == 0
+
+
+def test_name_filter_wildcard_case_sensitive(reinforced_t_section_geometry):
+    """Test wildcard filtering by name in case-sensitive mode."""
+    geo = reinforced_t_section_geometry
+
+    filtered = geo.name_filter('we*')
+
+    assert len(filtered) == 1
+    assert filtered[0].name == 'web'
+
+    filtered = geo.name_filter('we?')
+
+    assert len(filtered) == 1
+    assert filtered[0].name == 'web'
+
+
+def test_name_filter_wildcard_case_insensitive(reinforced_t_section_geometry):
+    """Test wildcard filtering by name in case-insensitive mode."""
+    geo = reinforced_t_section_geometry
+
+    filtered = geo.name_filter('*geo*', case_sensitive=False)
+
+    assert len(filtered) == 16
+    assert all(g.name.startswith('Geometry_') for g in filtered)
+
+
+def test_group_filter_wildcards(reinforced_t_section_geometry):
+    """Test wildcard filtering by reinforcement group labels."""
+    geo = reinforced_t_section_geometry
+
+    all_reinforcement = geo.group_filter('*reinf*')
+    bottom_reinforcement = geo.group_filter('bottom*')
+    top_reinforcement = geo.group_filter('top*')
+
+    assert len(all_reinforcement) == 16
+    assert len(bottom_reinforcement) == 4
+    assert len(top_reinforcement) == 12
+
+
+def test_group_filter_none_returns_all_geometries(
+    reinforced_t_section_geometry,
+):
+    """Test filtering by group_label with pattern=None."""
+    geo = reinforced_t_section_geometry
+
+    filtered = geo.group_filter(None)
+
+    assert len(filtered) == 18
+
+
+def test_group_filter_case_sensitive_option(reinforced_t_section_geometry):
+    """Test case sensitivity option when filtering by group_label."""
+    geo = reinforced_t_section_geometry
+
+    filtered_sensitive = geo.group_filter('*REINF*')
+    filtered_insensitive = geo.group_filter('*REINF*', case_sensitive=False)
+
+    assert len(filtered_sensitive) == 0
+    assert len(filtered_insensitive) == 16
+
+
+def test_combined_name_and_group_filters_intersection(
+    reinforced_t_section_geometry,
+):
+    """Test combining name and group filters through intersection."""
+    geo = reinforced_t_section_geometry
+
+    geom_name = geo.name_filter('we*')
+    geom_group = geo.group_filter(None)
+
+    filtered = list(set(geom_name) & set(geom_group))
+
+    assert len(filtered) == 1
+    assert filtered[0].name == 'web'

--- a/tests/test_geometry/test_filtering.py
+++ b/tests/test_geometry/test_filtering.py
@@ -122,6 +122,30 @@ def test_group_filter_wildcards(reinforced_t_section_geometry):
     assert len(top_reinforcement) == 12
 
 
+def test_group_filter_none_returns_split_dict(reinforced_t_section_geometry):
+    """Test filtering by group_label with pattern=None and split return."""
+    geo = reinforced_t_section_geometry
+
+    filtered = geo.group_filter(None, return_mode='split')
+
+    assert set(filtered.keys()) == {'surfaces', 'points'}
+    assert len(filtered['surfaces']) == 2
+    assert len(filtered['points']) == 16
+
+
+def test_group_filter_wildcards_returns_split_dict(
+    reinforced_t_section_geometry,
+):
+    """Test filtering by group_labele and split return."""
+    geo = reinforced_t_section_geometry
+
+    filtered = geo.group_filter('top*', return_mode='split')
+
+    assert set(filtered.keys()) == {'surfaces', 'points'}
+    assert len(filtered['surfaces']) == 0
+    assert len(filtered['points']) == 12
+
+
 def test_group_filter_none_returns_all_geometries(
     reinforced_t_section_geometry,
 ):


### PR DESCRIPTION
Add filtering potentialities based on name or group label used for geometries.

This supports passing `None` as a pattern string and get back all geometries. The `return_mode` can be `"split"` or `"flat"`. The former will return a dictionary with surface and point geometries separated, the second will return a single flattened list.

By default the match is case sensitive, but it can be optionally set to case insensitive if needed by the user.

Wildcards lie `'*'` or `'?'` are accepted. The backend used for matching is fnmatch.

Some examples are:

`geo.name_filter(None)` This will return the list of all surface and point geometries in the compound `geo`.
`geo.name_filter("we*")` This will return the list of all surfaces and point geometries which name matches the pattern `"we*"`
`geo.name_filter("web", return_mode="split")` This will return a dictionary with keys `'surfaces'` and `'points'` with the lists of surfaces and points geometries matching the pattern `"web"`
`geo.name_filter("*geo*", case_sensitive=False)` This will return the list of all surfaces and point geometries which name mathes the pattern `"*geo*"` case insensitive.
`geo.group_filter("*reinf*")` This will return the list of all surfaces and point geometries which group_name matches the pattern `"*reinf*"`

It is possible also to combine filters. For instance we can get the list of geometries matching different patterns for name and group_label:
```
geom_name = geo.name_filter("*geo*", case_sensitive=False)
geom_group = geo.group_filter("bottom*")

list(set(geom_name) & set(geom_group))
```

The implementation requires the following steps:

- [x] Implement the code for the feature at the geometry level
- [x] Add proper tests
- [x] Include the documentation