### PR TITLE
fix: guard perimeter computation for MultiPolygon geometries

### DIFF
--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -150,8 +150,8 @@ class GenericSectionCalculator(SectionCalculator):
             warnings.warn(
                 'Perimiter computation for a multi polygon is not defined.'
             )
-
-        gp.perimeter = polygon.exterior.length
+        else:
+            gp.perimeter = polygon.exterior.length
 
         # Computation of area: this is taken directly from shapely
         gp.area = self.section.geometry.area


### PR DESCRIPTION
## Bug
[#329](https://github.com/fib-international/structuralcodes/issues/329) — `gross_properties` raises `AttributeError: 'MultiPolygon' object has no attribute 'exterior'` when the section geometry is a `MultiPolygon` (e.g. disconnected rectangles).

## Fix
The `if isinstance(polygon, MultiPolygon)` block correctly sets `gp.perimeter = 0.0` and emits a warning, but the code then falls through to `polygon.exterior.length` unconditionally. This adds an `else` branch so the `.exterior` access only runs for single `Polygon` geometries.

## Testing
Verified that the code path now correctly short-circuits for `MultiPolygon` and only accesses `.exterior` on single `Polygon` instances. The existing test suite continues to pass for single-polygon sections.

Happy to address any feedback.

Greetings, saschabuehrle