### PR TITLE
fix: update iterative strain before convergence check

### DIFF
--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -1829,13 +1829,13 @@ class GenericSectionCalculator(SectionCalculator):
                 # Solve using the current tangent stiffness
                 delta_strain = np.linalg.solve(stiffness_tangent, residual)
 
+            # Update the strain
+            strain += delta_strain
+
             # Check for convergence:
             if np.linalg.norm(delta_strain) < tol:
                 converged = True
                 break
-
-            # Update the strain
-            strain += delta_strain
 
             num_iter += 1
 

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -1790,11 +1790,14 @@ class GenericSectionCalculator(SectionCalculator):
 
         # Calculate strain plane with Newton Rhapson Iterative method
         num_iter = 0
+        converged = False
         strain = np.zeros(3, dtype=float)
 
-        # The initial residual is equal to the loads
-        residual = loads.copy()
-        converged = False
+        # Calculate the initial response and residuals. Note that the initial
+        # residual might be different from the applied loads if any initial
+        # strain is present
+        response = self.integrate_strain_profile(strain=strain).asarray()
+        residual = loads - response
 
         residual_history = []
         strain_history = []

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -1773,7 +1773,7 @@ class GenericSectionCalculator(SectionCalculator):
         geom = self.section.geometry
 
         # Collect loads in a numpy array
-        loads = np.array([n, my, mz])
+        loads = np.array([n, my, mz], dtype=float)
 
         # Compute initial tangent stiffness matrix
         stiffness_tangent, integration_data = (
@@ -1791,7 +1791,9 @@ class GenericSectionCalculator(SectionCalculator):
         # Calculate strain plane with Newton Rhapson Iterative method
         num_iter = 0
         strain = np.zeros(3, dtype=float)
-        residual = np.zeros(3, dtype=float)
+
+        # The initial residual is equal to the loads
+        residual = loads.copy()
         converged = False
 
         residual_history = []
@@ -1809,14 +1811,6 @@ class GenericSectionCalculator(SectionCalculator):
             if num_iter > max_iter:
                 break
 
-            # Calculate response and residuals
-            response = self.integrate_strain_profile(strain=strain).asarray()
-            residual = loads - response
-
-            # Append to history variables
-            residual_history.append(residual.copy())
-            strain_history.append(strain.copy())
-
             if initial:
                 # Solve using the decomposed matrix
                 delta_strain = lu_solve((lu, piv), residual)
@@ -1831,6 +1825,14 @@ class GenericSectionCalculator(SectionCalculator):
 
             # Update the strain
             strain += delta_strain
+
+            # Calculate response and residuals
+            response = self.integrate_strain_profile(strain=strain).asarray()
+            residual = loads - response
+
+            # Append to history variables
+            residual_history.append(residual.copy())
+            strain_history.append(strain.copy())
 
             # Check for convergence:
             if np.linalg.norm(delta_strain) < tol:


### PR DESCRIPTION
After implementing the result object for calculate strain plane, the order of checking for convergence and updating the iterative strain was changed, resulting in a non-converged strain plane to be returned from the method.