### PR TITLE
fix: add last point to complete domain in nm_interaction_domain

### DIFF
--- a/structuralcodes/sections/_beam_section.py
+++ b/structuralcodes/sections/_beam_section.py
@@ -1374,9 +1374,9 @@ class BeamSectionCalculator(SectionCalculator):
                     type_6=type_6,
                 )
             )
-            strains = np.concatenate((strains, additional_strains[-2:0:-1]))
+            strains = np.concatenate((strains, additional_strains[-2::-1]))
             field_num = np.concatenate(
-                (field_num, additional_field_num[-2:0:-1])
+                (field_num, additional_field_num[-2::-1])
             )
 
         # integrate all strain profiles

--- a/tests/test_sections/test_beam_section.py
+++ b/tests/test_sections/test_beam_section.py
@@ -1730,16 +1730,16 @@ def test_mn_full_domain():
     # Combine theta = 0 and theta = 180 to obtain the full domain
     interaction_domain_full_combined_n = [
         *interaction_domain_0.n,
-        *interaction_domain_180.n[-2:0:-1],
+        *interaction_domain_180.n[-2::-1],
     ]
     interaction_domain_full_combined_my = [
         *interaction_domain_0.m_y,
-        *interaction_domain_180.m_y[-2:0:-1],
+        *interaction_domain_180.m_y[-2::-1],
     ]
 
     assert (
         len(interaction_domain_full.n)
-        == len(interaction_domain_0.n) + len(interaction_domain_180.n) - 2
+        == len(interaction_domain_0.n) + len(interaction_domain_180.n) - 1
     )
     assert np.allclose(
         interaction_domain_full.n, interaction_domain_full_combined_n


### PR DESCRIPTION
Added the last point in `nm_interaction_domain` when setting `complete_domain=True`. 
Indeed without this modification the following code:

```
import numpy as np
import matplotlib.pyplot as plt
from structuralcodes.geometry import RectangularGeometry
from structuralcodes.materials.basic import ElasticMaterial
from structuralcodes.sections import BeamSection

width = 200
height = 400
E = 10000
eps_u = 0.01

def elastic_rec_section() -> BeamSection:
    """Create a simple rectangular section with known properties."""
    # Square section centered at (0, 0)
    mat = ElasticMaterial(E=E, density=700, ultimate_strain=eps_u)

    geo = RectangularGeometry(width, height, mat)

    # It should not be concrete
    assert not geo.concrete

    return BeamSection(geo, integrator="marin")

sec = elastic_rec_section()
nm_domain_pos = sec.section_calculator.calculate_nm_interaction_domain()
nm_domain_neg = sec.section_calculator.calculate_nm_interaction_domain(theta=np.pi)
nm_domain_all = sec.section_calculator.calculate_nm_interaction_domain(complete_domain=True)

fig, axs = plt.subplots(1, 2, figsize=(12, 6))
axs[0].plot(nm_domain_pos.n * 1e-3, -nm_domain_pos.m_y * 1e-6, label="N-M Interaction Domain")
axs[0].plot(nm_domain_neg.n * 1e-3, -nm_domain_neg.m_y * 1e-6, label="N-M Interaction Domain (Negative)",)
axs[0].set_xlabel("N [kN]")
axs[0].set_ylabel("M_y [kNm]")
axs[0].legend()
axs[1].plot(nm_domain_all.n * 1e-3, -nm_domain_all.m_y * 1e-6, label="Complete N-M Interaction Domain",)
axs[1].set_xlabel("N [kN]")
axs[1].set_ylabel("M_y [kNm]")
axs[1].legend()
plt.show()
```

would produce the following picture (the full domain on the right plot is not closed).

<img width="1017" height="525" alt="image" src="https://github.com/user-attachments/assets/1619e862-66fd-499a-bb13-8c6484cc6944" />

After this PR the same code produces the following:

<img width="1017" height="525" alt="image" src="https://github.com/user-attachments/assets/a933072a-49f8-4f89-a4ff-319db8a4ef05" />
