### PR TITLE
fix: raise a deprecation warning if a GenericSection is created

### DIFF
--- a/structuralcodes/sections/__init__.py
+++ b/structuralcodes/sections/__init__.py
@@ -1,6 +1,7 @@
 """Main entry point for sections."""
 
 from ._beam_section import BeamSection, BeamSectionCalculator
+from ._generic import GenericSection
 from ._rc_utils import calculate_elastic_cracked_properties
 from .section_integrators import (
     FiberIntegrator,
@@ -11,6 +12,7 @@ from .section_integrators import (
 )
 
 __all__ = [
+    'GenericSection',
     'BeamSection',
     'BeamSectionCalculator',
     'SectionIntegrator',

--- a/structuralcodes/sections/_generic.py
+++ b/structuralcodes/sections/_generic.py
@@ -1,0 +1,28 @@
+"""The deprecated GenericSection class. Please use the BeamSection class
+instead.
+"""
+
+import warnings
+
+from ._beam_section import BeamSection
+
+
+class GenericSection(BeamSection):
+    """This is the GenericSection class which was renamed to BeamSection in
+    v0.7.0.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Since the GenericSection class was renamed to BeamSection in v0.7.0,
+        this will initialize a BeamSection.
+        """
+        warnings.warn(
+            (
+                'The GenericSection class was renamed to BeamSection in '
+                'v0.7.0. The GenericSection is scheduled for removal in a '
+                'future release. Please use the BeamSection class instead. An '
+                'object of type BeamSection is initialized.'
+            ),
+            category=DeprecationWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/tests/test_sections/test_generic.py
+++ b/tests/test_sections/test_generic.py
@@ -1,0 +1,25 @@
+"""Test initializing the deprecated GenericSection class."""
+
+import pytest
+from shapely import Polygon
+
+from structuralcodes.geometry import SurfaceGeometry
+from structuralcodes.materials.concrete import ConcreteMC2010
+from structuralcodes.sections import BeamSection, GenericSection
+
+
+# Test initializing a GenericSection
+def test_deprecated_generic_section():
+    """Test initializing the deprecated GenericSection."""
+    # Create materials to use
+    concrete = ConcreteMC2010(25)
+
+    # The section
+    poly = Polygon(((0, 0), (200, 0), (200, 400), (0, 400)))
+    geo = SurfaceGeometry(poly, concrete)
+
+    # Create the section
+    with pytest.warns(DeprecationWarning):
+        sec = GenericSection(geo)
+
+    assert isinstance(sec, BeamSection)


### PR DESCRIPTION
If a `GenericSection` is created, a `DeprecationWarning` is raised, and a `BeamSection` is created instead.