### PR TITLE
fix: revert changes to strain convention

### DIFF
--- a/structuralcodes/sections/section_integrators/_shell_integrator.py
+++ b/structuralcodes/sections/section_integrators/_shell_integrator.py
@@ -68,11 +68,8 @@ class ShellFiberIntegrator(SectionIntegrator):
 
         # A positive in-plane strain gives tension
         # A positive curvature gives a negative strain for a positive z-value
-        # Note the factor 2 for in-plane shear strain due to twisting curvature
         for z in z_coords:
-            fiber_strain = strain[:3].copy()
-            fiber_strain[:2] -= z * strain[3:5]
-            fiber_strain[2] -= 2 * z * strain[5]
+            fiber_strain = strain[:3] - z * strain[3:]
             if integrate == 'stress':
                 integrand = material.constitutive_law.get_stress(fiber_strain)
             elif integrate == 'modulus':
@@ -84,9 +81,7 @@ class ShellFiberIntegrator(SectionIntegrator):
             z_list.append(z)
 
         for r in geo.reinforcement:
-            fiber_strain = strain[:3].copy()
-            fiber_strain[:2] -= r.z * strain[3:5]
-            fiber_strain[2] -= 2 * r.z * strain[5]
+            fiber_strain = strain[:3] - r.z * strain[3:]
             eps_sj = r.T @ fiber_strain
 
             if integrate == 'stress':
@@ -153,9 +148,6 @@ class ShellFiberIntegrator(SectionIntegrator):
             B -= z_i * C_layer
             D += z_i**2 * C_layer
 
-        # This is necessary because the twisting moment is assumed proportional
-        # to the double twisting curvature
-        D[-1, -1] *= 2
         return np.block([[A, B], [B, D]])
 
     def integrate_strain_response_on_geometry(

--- a/tests/test_sections/test_shell_section.py
+++ b/tests/test_sections/test_shell_section.py
@@ -77,7 +77,7 @@ def test_integrate_strain_profile(
     Nxy = A_membrane_shear * eps_xy
     Mx = A_bending * (chi_x + nu * chi_y)
     My = A_bending * (chi_y + nu * chi_x)
-    Mxy = A_bending_shear * 2 * chi_xy
+    Mxy = A_bending_shear * chi_xy
 
     expected = np.array([Nx, Ny, Nxy, Mx, My, Mxy])
 
@@ -101,7 +101,7 @@ def test_integrate_strain_profile_stiffness_matrix(nu):
     A33 = E * t / (2 * (1 + nu))
     A44 = E * t**3 / 12 / (1 - nu**2)
     A14 = nu * A44
-    A55 = E * t**3 / 12 / (2 * (1 + nu)) * 2
+    A55 = E * t**3 / 12 / (2 * (1 + nu))
 
     A = np.array(
         [
@@ -162,7 +162,7 @@ def test_elastic_strain_profile(Ec, nu, t, nx, ny, nxy, mx, my, mxy):
     D = Ec * t**3 / (12 * (1 - nu**2))
     chi_x = (mx - nu * my) / (D * (1 - nu**2))
     chi_y = (my - nu * mx) / (D * (1 - nu**2))
-    chi_xy = mxy / (D * (1 - nu))
+    chi_xy = 2 * mxy / (D * (1 - nu))
     expected = np.array([eps_x, eps_y, eps_xy, chi_x, chi_y, chi_xy])
 
     assert np.allclose(eps, expected)


### PR DESCRIPTION
This reverts the changes from #339 such that the formulation is purely based on engineering convention for the membrane shear strain and the twisting curvature.