### PR TITLE
fix: annotate section_calculator of BeamSection to improve user experience

### DIFF
--- a/structuralcodes/sections/_beam_section.py
+++ b/structuralcodes/sections/_beam_section.py
@@ -44,6 +44,7 @@ class BeamSection(Section):
     """
 
     geometry: CompoundGeometry
+    section_calculator: BeamSectionCalculator
 
     def __init__(
         self,


### PR DESCRIPTION
After #331, the `section_calculator` attribute of the `BeamSection` is only annotated as the base class `SectionCalculator`, and the abstract methods were removed from the base class to avoid circular imports. `section_calculator` is now properly annotated as `BeamSectionCalculator` to give proper code hints in editors.