### PR TITLE
fix: wrong reference to integration data attribute

### DIFF
--- a/structuralcodes/sections/_beam_section.py
+++ b/structuralcodes/sections/_beam_section.py
@@ -559,7 +559,7 @@ class BeamSectionCalculator(SectionCalculator):
                 _,
                 _,
             ) = self.integrator.integrate_strain_response_on_geometry(
-                geom, [eps_0_b, curv, 0], tri=self.triangulated_data
+                geom, [eps_0_b, curv, 0], tri=self.integration_data
             )
             dn_b = n_int - n
             if dn_a * dn_b < 0:
@@ -595,7 +595,7 @@ class BeamSectionCalculator(SectionCalculator):
                 ) = self.integrator.integrate_strain_response_on_geometry(
                     geom,
                     [eps_0_attempts[j], curv, 0],
-                    tri=self.triangulated_data,
+                    tri=self.integration_data,
                 )
                 dn_attempts[j] = n_int - n
             if dn_a > 0:

--- a/tests/test_sections/test_beam_section.py
+++ b/tests/test_sections/test_beam_section.py
@@ -2019,3 +2019,59 @@ def test_perimeter_multipolygon():
         gp = section.gross_properties
 
     assert math.isclose(gp.perimeter, 0)
+
+
+def test_wide_section():
+    """Test calculating the moment-curvature relation for a wide section.
+
+    Regression test for #362. Based on the geometry from the quickstart example
+    with an increased width.
+    """
+    # Create a concrete and a reinforcement
+    fck = 45
+    fyk = 500
+    ftk = 550
+    Es = 200000
+    epsuk = 0.07
+
+    concrete = ConcreteEC2_2004(fck=fck)
+    reinforcement = ReinforcementEC2_2004(fyk=fyk, Es=Es, ftk=ftk, epsuk=epsuk)
+
+    # Create a rectangular geometry
+    width = 1000
+    height = 500
+
+    geometry = RectangularGeometry(
+        width=width, height=height, material=concrete
+    )
+
+    # Add reinforcement
+    diameter_reinf = 25
+    cover = 50
+
+    geometry = add_reinforcement(
+        geometry,
+        (
+            -width / 2 + cover + diameter_reinf / 2,
+            -height / 2 + cover + diameter_reinf / 2,
+        ),
+        diameter_reinf,
+        reinforcement,
+    )  # The add_reinforcement function returns a CompoundGeometry
+    geometry = add_reinforcement(
+        geometry,
+        (
+            width / 2 - cover - diameter_reinf / 2,
+            -height / 2 + cover + diameter_reinf / 2,
+        ),
+        diameter_reinf,
+        reinforcement,
+    )
+
+    # Create section
+    section = BeamSection(geometry)
+
+    # Calculate the moment-curvature response
+    moment_curvature = section.section_calculator.calculate_moment_curvature()
+
+    assert moment_curvature is not None


### PR DESCRIPTION
Two references to the attribute `triangulated_data` that were missed in #296 are now corrected.