### PR TITLE
docs: update docs

### DIFF
--- a/docs/api/geometry/geometry_creation.md
+++ b/docs/api/geometry/geometry_creation.md
@@ -15,6 +15,7 @@
     .. autoproperty:: x
     .. autoproperty:: y
     .. autoproperty:: point
+    .. autoproperty:: group_label
 
     .. automethod:: translate
     .. automethod:: rotate
@@ -34,6 +35,7 @@
     .. autoproperty:: area
     .. autoproperty:: centroid
     .. autoproperty:: density
+    .. autoproperty:: group_label
 
     .. automethod:: translate
     .. automethod:: rotate
@@ -95,6 +97,7 @@ In this section the classes and methods for creating special and common geometri
 
     .. autoproperty:: height
     .. autoproperty:: width
+    .. autoproperty:: group_label
 
 ```
 
@@ -105,6 +108,7 @@ In this section the classes and methods for creating special and common geometri
 
     .. autoproperty:: radius
     .. autoproperty:: diameter
+    .. autoproperty:: group_label
 
 ```
 
@@ -133,6 +137,5 @@ In this section the classes and methods for creating special and common geometri
     .. automethod:: __init__
 
     .. autoproperty:: name
-    .. autoproperty:: group_label
 
 ```

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -43,6 +43,6 @@ py -m pip install --upgrade structuralcodes
 
 :::{tip}
 
-If you are on Windows, we recommend using [Python install manager]() for installing and managing Python runtimes. Install the Python install manager with `winget` by typing `winget install python.pythoninstallmanager`.
+If you are on Windows, we recommend using [Python install manager](https://docs.python.org/3/using/windows.html#python-install-manager) for installing and managing Python runtimes. Install the Python install manager with `winget` by typing `winget install python.pythoninstallmanager`.
 
 :::

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -12,7 +12,7 @@ python -m pip install structuralcodes
 :::
 ::::
 
-::::{tab-item} Python launcher
+::::{tab-item} Python install manager
 :sync: py
 
 :::{code-block} pwsh
@@ -32,7 +32,7 @@ python -m pip install --upgrade structuralcodes
 :::
 ::::
 
-::::{tab-item} Python launcher
+::::{tab-item} Python install manager
 :sync: py
 
 :::{code-block} pwsh
@@ -40,3 +40,9 @@ py -m pip install --upgrade structuralcodes
 :::
 ::::
 :::::
+
+:::{tip}
+
+If you are on Windows, we recommend using [Python install manager]() for installing and managing Python runtimes. Install the Python install manager with `winget` by typing `winget install python.pythoninstallmanager`.
+
+:::


### PR DESCRIPTION
Two minor fixes for the docs:
- The reference to the attribute `group_label` is moved to the geometry classes that have this attribute implemented.
- A tip about using the Python install manager is added in the installation guide.