### PR TITLE
fix: fix marin integration for more than one reinforcement material

### DIFF
--- a/structuralcodes/sections/section_integrators/_marin_integrator.py
+++ b/structuralcodes/sections/section_integrators/_marin_integrator.py
@@ -223,9 +223,6 @@ class MarinIntegrator(SectionIntegrator):
             )
         # Now use the integration data (either just created or passed as
         # argument) to fill the input
-        y = []
-        z = []
-        IA = []
         for reinf_data in integration_data:
             # All have the same constitutive law
             strains = strain[0] + strain[1] * reinf_data[1]
@@ -236,19 +233,17 @@ class MarinIntegrator(SectionIntegrator):
                 integrand = reinf_data[3].get_tangent(strains)
             else:
                 raise ValueError(f'Unknown integrate type: {integrate}')
-            y.append(reinf_data[0])
-            z.append(reinf_data[1])
-            IA.append(integrand * reinf_data[2])
+            # Append integration data to prepared input
+            input.append(
+                (
+                    1,
+                    reinf_data[0],  # The y-coordinate
+                    reinf_data[1],  # The z-coordinate
+                    integrand
+                    * reinf_data[2],  # The integrand multiplied with the area
+                )
+            )
 
-        try:
-            # This is necessary if there is more than one constitutive law for
-            # the point geometries, and there is an unequal number of point
-            # geometries for each constitutive law
-            input.append((1, np.hstack(y), np.hstack(z), np.hstack(IA)))
-        except ValueError:
-            # If there are no point geometries np.hstack fails and raises a
-            # ValueError
-            input.append((1, np.array(y), np.array(z), np.array(IA)))
         return integration_data
 
     def prepare_input(

--- a/structuralcodes/sections/section_integrators/_marin_integrator.py
+++ b/structuralcodes/sections/section_integrators/_marin_integrator.py
@@ -240,7 +240,15 @@ class MarinIntegrator(SectionIntegrator):
             z.append(reinf_data[1])
             IA.append(integrand * reinf_data[2])
 
-        input.append((1, np.array(y), np.array(z), np.array(IA)))
+        try:
+            # This is necessary if there is more than one constitutive law for
+            # the point geometries, and there is an unequal number of point
+            # geometries for each constitutive law
+            input.append((1, np.hstack(y), np.hstack(z), np.hstack(IA)))
+        except ValueError:
+            # If there are no point geometries np.hstack fails and raises a
+            # ValueError
+            input.append((1, np.array(y), np.array(z), np.array(IA)))
         return integration_data
 
     def prepare_input(

--- a/tests/test_sections/test_beam_section.py
+++ b/tests/test_sections/test_beam_section.py
@@ -2080,3 +2080,79 @@ def test_wide_section():
     moment_curvature = section.section_calculator.calculate_moment_curvature()
 
     assert moment_curvature is not None
+
+
+def test_marin_integrator_two_reinforcement_materials():
+    """Test using Marin integrator on a geometry with two different
+    reinforcement materials present.
+
+    Regression test for #368. Based on geometry from quickstart example.
+    """
+    # Create a concrete and a reinforcement
+    fck = 45
+    fyk = 500
+    ftk = 550
+    Es = 200000
+    epsuk = 0.07
+
+    concrete = ConcreteEC2_2004(fck=fck)
+    reinforcement_1 = ReinforcementEC2_2004(
+        fyk=fyk, Es=Es, ftk=ftk, epsuk=epsuk
+    )
+    reinforcement_2 = ReinforcementEC2_2004(
+        fyk=fyk, Es=Es, ftk=ftk, epsuk=epsuk
+    )
+
+    # Create a rectangular geometry
+    width = 250
+    height = 500
+
+    geometry = RectangularGeometry(
+        width=width, height=height, material=concrete
+    )
+
+    # Add reinforcement
+    diameter_reinf = 25
+    cover = 50
+    n_bars_top = 2
+    n_bars_bot = 4
+
+    geometry = add_reinforcement_line(
+        geometry,
+        (
+            -width / 2 + cover + diameter_reinf / 2,
+            -height / 2 + cover + diameter_reinf / 2,
+        ),
+        (
+            width / 2 - cover - diameter_reinf / 2,
+            -height / 2 + cover + diameter_reinf / 2,
+        ),
+        diameter_reinf,
+        reinforcement_1,
+        n_bars_bot,
+    )
+    geometry = add_reinforcement_line(
+        geometry,
+        (
+            -width / 2 + cover + diameter_reinf / 2,
+            height / 2 - cover - diameter_reinf / 2,
+        ),
+        (
+            width / 2 - cover - diameter_reinf / 2,
+            height / 2 - cover - diameter_reinf / 2,
+        ),
+        diameter_reinf,
+        reinforcement_2,
+        n_bars_top,
+    )
+
+    # Create section, make sure that the Marin integrator is used
+    section = BeamSection(geometry, integrator='marin')
+
+    # Trigger formulation of integration data by integrating a dummy strain
+    # profile
+    integration_result = section.section_calculator.integrate_strain_profile(
+        np.zeros(3)
+    )
+
+    assert integration_result is not None

--- a/tests/test_sections/test_beam_section.py
+++ b/tests/test_sections/test_beam_section.py
@@ -2117,8 +2117,7 @@ def test_marin_integrator_two_reinforcement_materials():
     n_bars_top = 2
     n_bars_bot = 4
 
-    geometry = add_reinforcement_line(
-        geometry,
+    coords_bottom_reinf = (
         (
             -width / 2 + cover + diameter_reinf / 2,
             -height / 2 + cover + diameter_reinf / 2,
@@ -2127,32 +2126,64 @@ def test_marin_integrator_two_reinforcement_materials():
             width / 2 - cover - diameter_reinf / 2,
             -height / 2 + cover + diameter_reinf / 2,
         ),
+    )
+    coords_top_reinf = (
+        (
+            -width / 2 + cover + diameter_reinf / 2,
+            height / 2 - cover - diameter_reinf / 2,
+        ),
+        (
+            width / 2 - cover - diameter_reinf / 2,
+            height / 2 - cover - diameter_reinf / 2,
+        ),
+    )
+
+    geometry_one_material = add_reinforcement_line(
+        geometry,
+        *coords_bottom_reinf,
         diameter_reinf,
         reinforcement_1,
         n_bars_bot,
     )
-    geometry = add_reinforcement_line(
+    geometry_one_material = add_reinforcement_line(
+        geometry_one_material,
+        *coords_top_reinf,
+        diameter_reinf,
+        reinforcement_1,
+        n_bars_top,
+    )
+    geometry_two_materials = add_reinforcement_line(
         geometry,
-        (
-            -width / 2 + cover + diameter_reinf / 2,
-            height / 2 - cover - diameter_reinf / 2,
-        ),
-        (
-            width / 2 - cover - diameter_reinf / 2,
-            height / 2 - cover - diameter_reinf / 2,
-        ),
+        *coords_bottom_reinf,
+        diameter_reinf,
+        reinforcement_1,
+        n_bars_bot,
+    )
+    geometry_two_materials = add_reinforcement_line(
+        geometry_two_materials,
+        *coords_top_reinf,
         diameter_reinf,
         reinforcement_2,
         n_bars_top,
     )
 
     # Create section, make sure that the Marin integrator is used
-    section = BeamSection(geometry, integrator='marin')
+    section_one_material = BeamSection(
+        geometry_one_material, integrator='marin'
+    )
+    section_two_materials = BeamSection(
+        geometry_two_materials, integrator='marin'
+    )
 
     # Trigger formulation of integration data by integrating a dummy strain
     # profile
-    integration_result = section.section_calculator.integrate_strain_profile(
-        np.zeros(3)
-    )
+    bending_strength_one_material = (
+        section_one_material.section_calculator.calculate_bending_strength()
+    ).m_y
+    bending_strength_two_materials = (
+        section_two_materials.section_calculator.calculate_bending_strength()
+    ).m_y
 
-    assert integration_result is not None
+    assert math.isclose(
+        bending_strength_one_material, bending_strength_two_materials
+    )


### PR DESCRIPTION
The Marin integrator fails when more than one reinforcement material is present and the number of points for each material is different. This is an attempt to fix this behavior.