### PR TITLE
fix: cast principal area moments to real type to ensure no imaginary part

### DIFF
--- a/structuralcodes/geometry/profiles/_base_profile.py
+++ b/structuralcodes/geometry/profiles/_base_profile.py
@@ -122,10 +122,12 @@ class BaseProfile:
         )
         max_idx = np.argmax(eigres[0])
         min_idx = 0 if max_idx == 1 else 1
-        self._Icsi = eigres[0][max_idx]
-        self._Ieta = eigres[0][min_idx]
-        self._theta = np.arccos(
-            np.dot(np.array([1, 0]), eigres[1][:, max_idx])
+        # The principal values are cast to real type to ensure no imaginary
+        # part is present
+        self._Icsi = np.real(eigres[0][max_idx])
+        self._Ieta = np.real(eigres[0][min_idx])
+        self._theta = np.real(
+            np.arccos(np.dot(np.array([1, 0]), eigres[1][:, max_idx]))
         )
 
     @property

--- a/structuralcodes/sections/_beam_section.py
+++ b/structuralcodes/sections/_beam_section.py
@@ -283,9 +283,13 @@ class BeamSectionCalculator(SectionCalculator):
             eigres = np.linalg.eig(np.array([[iyy, iyz], [iyz, izz]]))
             max_idx = np.argmax(eigres[0])
             min_idx = 0 if max_idx == 1 else 1
-            i11 = eigres[0][max_idx]
-            i22 = eigres[0][min_idx]
-            theta = np.arccos(np.dot(np.array([1, 0]), eigres[1][:, max_idx]))
+            # The principal values are cast to real type to ensure no imaginary
+            # part is present
+            i11 = np.real(eigres[0][max_idx])
+            i22 = np.real(eigres[0][min_idx])
+            theta = np.real(
+                np.arccos(np.dot(np.array([1, 0]), eigres[1][:, max_idx]))
+            )
             return i11, i22, theta
 
         gp.i11, gp.i22, gp.theta = find_principal_axes_moments(


### PR DESCRIPTION
With numpy>2.5 the results from `linalg.eig` seem to include an imaginary part although the value of the imaginary part is `0j`. This change makes sure the principal moments computed with `linalg.eig` are cast to real types before they are stored as properties.